### PR TITLE
Upload directly to s3

### DIFF
--- a/Jenkinsfile-authoriser-test
+++ b/Jenkinsfile-authoriser-test
@@ -53,7 +53,7 @@ library("tdr-jenkinslib")
             steps {
               script {
                 unstash "${libraryName}-jar"
-                tdr.copyToS3CodeBucket(libraryName, versionTag)
+                sh "aws s3 cp authoriser/target/scala-${scalaVersion}/${libraryName}.jar s3://tdr-backend-code-mgmt/${versionTag}/${libraryName}.jar"
 
                 tdr.configureJenkinsGitUser()
 


### PR DESCRIPTION
This was originally using the tdr function for uploading to S3 but this
is expecting the target directory to be at the top level which it isn't
in this multi project repo. Seeing as it's one line, there's no reason
not to upload this directly.
