### PR TITLE
Use the correct lambda name.

### DIFF
--- a/Jenkinsfile-authoriser-deploy
+++ b/Jenkinsfile-authoriser-deploy
@@ -2,7 +2,7 @@ library("tdr-jenkinslib")
 
 deployToLambda(
   stage: params.STAGE,
-  libraryName: "consignment-export",
+  libraryName: "export-api-authoriser",
   version: params.TO_DEPLOY,
   deploymentPackageName: "consignment-export.jar"
 )


### PR DESCRIPTION
The name of the lambda is tdr-export-api-authoriser-${env}. I've updated the deploy
job so this matches.
