### PR TITLE
Ensure p11-kit version updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:16-alpine
 RUN apk add --no-cache bash tar && \
+    apk update && \
+    apk upgrade p11-kit && \
     adduser consignment-export -D
 WORKDIR /home/consignment-export
 USER consignment-export


### PR DESCRIPTION
Fix for a number of security vulnerabilities identified with an older version of the p11-kit: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29363; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29362; https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29361