### PR TITLE
Downgrade the JDK from version 16 to 15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:16-alpine
+FROM openjdk:15-alpine
 RUN apk add --no-cache bash tar && \
     apk update && \
     apk upgrade p11-kit && \


### PR DESCRIPTION
Version 15 is the latest stable release. Version 16 seems to work on this project, but has been causing errors in tdr-transfer-frontend: nationalarchives/tdr-transfer-frontend#393