### PR TITLE
Throw error if files are missing.

### DIFF
--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -27,6 +27,7 @@ object Main extends CommandIOApp("tdr-consignment-export", "Exports tdr files in
         s3Files = S3Files(S3Utils(s3Async))
 
         data <- graphQlApi.getFiles(config, consignmentId)
+        _ <- IO.fromOption(data.headOption)(new Exception(s"No files found for consignment $consignmentId"))
         _ <- s3Files.downloadFiles(data, config.s3.cleanBucket, consignmentId, config.efs.rootLocation)
         _ <- Bagit().createBag(consignmentId, config.efs.rootLocation)
         // The owner and group in the below command have no effect on the file permissions. It just makes tar idempotent

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -27,7 +27,7 @@ object Main extends CommandIOApp("tdr-consignment-export", "Exports tdr files in
         s3Files = S3Files(S3Utils(s3Async))
 
         data <- graphQlApi.getFiles(config, consignmentId)
-        _ <- IO.fromOption(data.headOption)(new Exception(s"No files found for consignment $consignmentId"))
+        _ <- IO.fromOption(data.headOption)(new Exception(s"Consignment API returned no files for consignment $consignmentId"))
         _ <- s3Files.downloadFiles(data, config.s3.cleanBucket, consignmentId, config.efs.rootLocation)
         _ <- Bagit().createBag(consignmentId, config.efs.rootLocation)
         // The owner and group in the below command have no effect on the file permissions. It just makes tar idempotent

--- a/exporter/src/test/resources/json/get_files_empty.json
+++ b/exporter/src/test/resources/json/get_files_empty.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "getFiles": {
+      "fileIds": []
+    }
+  }
+}

--- a/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
+++ b/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
@@ -62,6 +62,10 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
     .withRequestBody(equalToJson("{\"query\":\"query getFiles($consignmentId:UUID!){getFiles(consignmentid:$consignmentId){fileIds}}\",\"variables\":{\"consignmentId\":\"50df01e6-2e5e-4269-97e7-531a755b417d\"}}"))
     .willReturn(okJson(fromResource(s"json/get_files.json").mkString)))
 
+  def graphqlGetEmptyFiles: StubMapping = wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
+    .withRequestBody(equalToJson("{\"query\":\"query getFiles($consignmentId:UUID!){getFiles(consignmentid:$consignmentId){fileIds}}\",\"variables\":{\"consignmentId\":\"6794231c-39fe-41e0-a498-b6a077563282\"}}"))
+    .willReturn(okJson(fromResource(s"json/get_files_empty.json").mkString)))
+
   def graphqlUpdateExportLocation: StubMapping = wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
     .willReturn(okJson(fromResource(s"json/get_files.json").mkString)))
 
@@ -84,7 +88,6 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
   override def beforeEach(): Unit = {
     authOk
     wiremockGraphqlServer.resetAll()
-    graphqlGetFiles
     graphqlUpdateExportLocation
     graphqlGetOriginalPath
     createBucket("test-clean-bucket")

--- a/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/MainSpec.scala
+++ b/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/MainSpec.scala
@@ -17,6 +17,7 @@ import scala.jdk.CollectionConverters._
 class MainSpec extends ExternalServiceSpec {
 
   "the export job" should "export the correct tar and checksum file" in {
+    graphqlGetFiles
     val consignmentId = UUID.fromString("50df01e6-2e5e-4269-97e7-531a755b417d")
     putFile(s"$consignmentId/7b19b272-d4d1-4d77-bf25-511dc6489d12")
     Main.run(List("export", "--consignmentId", consignmentId.toString)).unsafeRunSync()
@@ -28,6 +29,7 @@ class MainSpec extends ExternalServiceSpec {
   }
 
   "the export job" should "export a valid tar and checksum file" in {
+    graphqlGetFiles
     val consignmentId = UUID.fromString("50df01e6-2e5e-4269-97e7-531a755b417d")
     putFile(s"$consignmentId/7b19b272-d4d1-4d77-bf25-511dc6489d12")
     Main.run(List("export", "--consignmentId", consignmentId.toString)).unsafeRunSync()
@@ -48,6 +50,7 @@ class MainSpec extends ExternalServiceSpec {
   }
 
   "the export job" should "update the export location in the api" in {
+    graphqlGetFiles
     val consignmentId = UUID.fromString("50df01e6-2e5e-4269-97e7-531a755b417d")
     putFile(s"$consignmentId/7b19b272-d4d1-4d77-bf25-511dc6489d12")
     Main.run(List("export", "--consignmentId", consignmentId.toString)).unsafeRunSync()
@@ -57,5 +60,15 @@ class MainSpec extends ExternalServiceSpec {
 
     exportLocationEvent.isDefined should be(true)
     exportLocationEvent.get.getRequest.getBodyAsString.contains("\"consignmentId\":\"50df01e6-2e5e-4269-97e7-531a755b417d\"") should be(true)
+  }
+
+  "the export job" should "throw an error if the api returns no files for the consignment" in {
+    graphqlGetEmptyFiles
+    val consignmentId = "6794231c-39fe-41e0-a498-b6a077563282"
+
+    val ex = intercept[Exception] {
+      Main.run(List("export", "--consignmentId", consignmentId)).unsafeRunSync()
+    }
+    ex.getMessage should equal(s"Consignment API returned no files for consignment $consignmentId")
   }
 }


### PR DESCRIPTION
What was happening if you ran this with a non existent consignment was it would try to get the files from the api and the api would return nothing.
This empty list was passed to the s3 downloader which would download nothing.
The program would continue until we had a bagit package with an empty data directory.
Arguably, the API should be rejecting non-existent consignments but for now, this will throw an error if no files are returned by the api.
