### PR TITLE
Replace mkdir with File API

### DIFF
--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Arguments.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Arguments.scala
@@ -2,7 +2,6 @@ package uk.gov.nationalarchives.consignmentexport
 
 import java.util.UUID
 
-import cats.implicits._
 import com.monovore.decline.Opts
 
 object Arguments {

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/GraphQlApi.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/GraphQlApi.scala
@@ -14,7 +14,6 @@ import sttp.client.{HttpURLConnectionBackend, Identity, NothingT, SttpBackend}
 import GraphQlApi._
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import uk.gov.nationalarchives.consignmentexport.Config.Configuration
-import uk.gov.nationalarchives.tdr.error.GraphQlError
 
 import scala.concurrent.{ExecutionContextExecutor, Future}
 
@@ -41,7 +40,7 @@ class GraphQlApi(keycloak: KeycloakUtils,
     _ <- logger.info(s"Export location updated for consignment $consignmentId")
   } yield data.updateExportLocation
 
-  def getOriginalPath(config: Configuration, fileId: UUID) = for {
+  def getOriginalPath(config: Configuration, fileId: UUID): IO[FileIdWithPath] = for {
     token <- keycloak.serviceAccountToken(config.auth.clientId, config.auth.clientSecret).toIO
     response <- getOriginalPathClient.getResult(token, gop.document, gop.Variables(fileId).some).toIO
     data <- IO.fromOption(response.data)(new RuntimeException(s"No data returned from the original path call for file id $fileId ${response.errorString}"))

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -1,7 +1,5 @@
 package uk.gov.nationalarchives.consignmentexport
 
-import java.io.File
-
 import cats.effect._
 import com.monovore.decline.Opts
 import com.monovore.decline.effect.CommandIOApp

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
@@ -18,7 +18,6 @@ import scala.sys.process._
 class S3Files(s3Utils: S3Utils)(implicit val logger: SelfAwareStructuredLogger[IO]) {
 
   def downloadFiles(files: List[FileIdWithPath], bucket: String, consignmentId: UUID, rootLocation: String): IO[Unit] = for {
-    _ <- IO.pure(new File(s"$rootLocation/$consignmentId").mkdirs())
     _ <- files.map(file => {
       val writeDirectory = file.originalPath.split("/").init.mkString("/")
       new File(s"$rootLocation/$consignmentId/$writeDirectory").mkdirs()

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
@@ -1,5 +1,6 @@
 package uk.gov.nationalarchives.consignmentexport
 
+import java.io.File
 import java.nio.file.{Path, Paths}
 import java.util.UUID
 
@@ -17,10 +18,10 @@ import scala.sys.process._
 class S3Files(s3Utils: S3Utils)(implicit val logger: SelfAwareStructuredLogger[IO]) {
 
   def downloadFiles(files: List[FileIdWithPath], bucket: String, consignmentId: UUID, rootLocation: String): IO[Unit] = for {
-    _ <- IO.pure(s"mkdir -p $rootLocation/$consignmentId" !!)
+    _ <- IO.pure(new File(s"$rootLocation/$consignmentId").mkdirs())
     _ <- files.map(file => {
       val writeDirectory = file.originalPath.split("/").init.mkString("/")
-      s"mkdir -p $rootLocation/$consignmentId/$writeDirectory".!!
+      new File(s"$rootLocation/$consignmentId/$writeDirectory").mkdirs()
       s3Utils.downloadFiles(bucket, s"$consignmentId/${file.fileId}", s"$rootLocation/$consignmentId/${file.originalPath}".toPath.some)
     }).sequence
     _ <- logger.info(s"Files downloaded from S3 for consignment $consignmentId")

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
@@ -1,19 +1,16 @@
 package uk.gov.nationalarchives.consignmentexport
 
 import java.io.File
-import java.nio.file.{Path, Paths}
 import java.util.UUID
 
 import cats.effect.IO
 import cats.implicits._
-import graphql.codegen.GetFiles.getFiles.Data
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import uk.gov.nationalarchives.aws.utils.S3Utils
-import Utils._
 import uk.gov.nationalarchives.consignmentexport.GraphQlApi.FileIdWithPath
+import uk.gov.nationalarchives.consignmentexport.Utils._
 
 import scala.language.postfixOps
-import scala.sys.process._
 
 class S3Files(s3Utils: S3Utils)(implicit val logger: SelfAwareStructuredLogger[IO]) {
 


### PR DESCRIPTION
We were calling mkdir but this has trouble with quotes in file names. If you pass the original path string to a File object and call mkdirs() then it sorts out any character escaping for you.
