### PR TITLE
Run each export in a unique directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ You can also run `sbt universal:packageZipTarball` which creates a file `target/
 ### Deployment
 Because this is run as an on demand ECS task, deployment is just pushing a new version of the docker image to ECR with the appropriate stage tag. This will be done by Jenkins as part of the deploy job on merge to master so there should be no reason to do this locally.
 
+### Tests
+
+Run `sbt tests` to run the tests in both projects.
+
+The exporter tests write temporary files to the directory defined in `efs.rootLocation` in the test application.conf. By default, it uses the `/tmp` directory. To use a different directory, set the `SCRATCH_DIRECTORY` environment variable when running the tests.
+
 ### Troubleshooting
 
 You might see this error if your `tar` installation is not GNU Tar, since some Unix OSes like MacOS use a different `tar` by default:

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -1,5 +1,7 @@
 package uk.gov.nationalarchives.consignmentexport
 
+import java.util.UUID
+
 import cats.effect._
 import com.monovore.decline.Opts
 import com.monovore.decline.effect.CommandIOApp
@@ -19,7 +21,9 @@ object Main extends CommandIOApp("tdr-consignment-export", "Exports tdr files in
      exportOps.map {
       case FileExport(consignmentId) => for {
         config <- config()
-        basePath = config.efs.rootLocation
+        rootLocation = config.efs.rootLocation
+        exportId = UUID.randomUUID
+        basePath = s"$rootLocation/$exportId"
         tarPath = s"${basePath}/$consignmentId.tar.gz"
         bashCommands = BashCommands()
         graphQlApi = GraphQlApi(config.api.url, config.auth.url)

--- a/exporter/src/test/resources/application.conf
+++ b/exporter/src/test/resources/application.conf
@@ -5,7 +5,8 @@ s3 {
 }
 
 efs {
-    rootLocation = "src/test/resources/testfiles"
+    rootLocation = "/tmp/tdr-consignment-export-scratch"
+    rootLocation = ${?SCRATCH_DIRECTORY}
 }
 
 api {

--- a/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
+++ b/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
@@ -5,29 +5,32 @@ import java.net.URI
 import java.nio.file.Path
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, get, okJson, post, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import com.typesafe.config.{Config, ConfigFactory}
 import io.findify.s3mock.S3Mock
 import org.keycloak.OAuth2Constants
 import org.keycloak.admin.client.{Keycloak, KeycloakBuilder}
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{CreateBucketRequest, CreateBucketResponse, DeleteBucketRequest, DeleteBucketResponse, GetObjectRequest, GetObjectResponse, ListObjectsRequest, PutObjectRequest, PutObjectResponse, S3Object}
+import software.amazon.awssdk.services.s3.model._
 
 import scala.concurrent.ExecutionContext
 import scala.io.Source.fromResource
-import scala.sys.process._
 import scala.jdk.CollectionConverters._
-import scala.util.Try
+import scala.sys.process._
 
 class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with BeforeAndAfterAll with ScalaFutures with Matchers {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(5, Seconds)), interval = scaled(Span(100, Millis)))
+
+  private val appConfig: Config = ConfigFactory.load()
+  val scratchDirectory: String = appConfig.getString("efs.rootLocation")
 
   val s3Client: S3Client = S3Client.builder
     .region(Region.EU_WEST_2)
@@ -112,6 +115,7 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
   override def beforeAll(): Unit = {
     wiremockGraphqlServer.start()
     wiremockAuthServer.start()
+    new File(scratchDirectory).mkdirs()
   }
 
   override def beforeEach(): Unit = {
@@ -135,6 +139,6 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
     deleteBucket("test-output-bucket")
     wiremockAuthServer.resetAll()
     wiremockGraphqlServer.resetAll()
-    Seq("sh", "-c", "rm -r src/test/resources/testfiles/50df01e6-2e5e-4269-97e7-531a755b417d*").!
+    Seq("sh", "-c", s"rm -r $scratchDirectory/*").!
   }
 }


### PR DESCRIPTION
Generate a random folder name for each export. This means that if the export task is started twice for the same consignment, the two tasks don't try to read and write the same files in EFS. It also means that we don't have to clean up the files after running the export, because a future export of the same consignment will use a different folder.

This should help to prevent failed exports or corrupted Bagit packages.

Also tests to use /tmp as a temporary directory, rather than src/test/resources, which had a couple of problems:

- It's a relative directory, so it only referenced the expected directory if you ran the tests using `sbt test`. If you used IntelliJ instead, it would create a new src/test/resources directory in the project's root directory instead.
- There are files in src/test/resources which need to be kept. This make it fiddly to tidy up specific test data.

We were already using /tmp for the fake S3 server, so use /tmp for the scratch export directory too. Also add an environment variable called `SCRATCH_DIRECTORY` which can be used to set a different scratch directory for the tests.