### PR TITLE
Replace IO.pure when running file system and API commands 

### DIFF
--- a/authoriser/src/main/scala/uk/gov/nationalarchives/consignmentexport/authoriser/Lambda.scala
+++ b/authoriser/src/main/scala/uk/gov/nationalarchives/consignmentexport/authoriser/Lambda.scala
@@ -37,7 +37,7 @@ class Lambda {
     config <- Blocker[IO].use(ConfigSource.default.loadF[IO, Configuration])
     graphQLClient = new GraphQLClient[Data, Variables](config.api.url)
     consignmentId = UUID.fromString(input.methodArn.split("/").last)
-    result <- IO.fromFuture(IO.pure(graphQLClient.getResult(new BearerAccessToken(input.authorizationToken), document, Variables(consignmentId).some)))
+    result <- IO.fromFuture(IO(graphQLClient.getResult(new BearerAccessToken(input.authorizationToken), document, Variables(consignmentId).some)))
   } yield {
     val effect = result.errors.headOption match {
       case Some(_) => "Deny"

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Bagit.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/Bagit.scala
@@ -19,8 +19,8 @@ class Bagit(bagInPlace: (Path, util.Collection[SupportedAlgorithm], Boolean) => 
             validateBag: (Bag, Boolean) => Unit)(implicit val logger: SelfAwareStructuredLogger[IO]) {
 
   def createBag(consignmentId: UUID, rootLocation: String): IO[Unit] = for {
-    bag <- IO.pure(bagInPlace(s"$rootLocation/$consignmentId".toPath, List(StandardSupportedAlgorithms.SHA256: SupportedAlgorithm).asJavaCollection, true))
-    _ <- IO.pure(validateBag(bag, true))
+    bag <- IO(bagInPlace(s"$rootLocation/$consignmentId".toPath, List(StandardSupportedAlgorithms.SHA256: SupportedAlgorithm).asJavaCollection, true))
+    _ <- IO(validateBag(bag, true))
     _ <- logger.info(s"Bagit export complete for consignment $consignmentId")
   } yield ()
 }

--- a/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/BashCommands.scala
+++ b/exporter/src/main/scala/uk/gov/nationalarchives/consignmentexport/BashCommands.scala
@@ -12,7 +12,7 @@ import scala.sys.process._
 class BashCommands(outputToFile: (String, File) => IO[Unit])(implicit val logger: SelfAwareStructuredLogger[IO]) {
 
   def runCommand(command: String): IO[String] = for {
-    output <- IO.pure(Seq("sh", "-c", command) !!)
+    output <- IO(Seq("sh", "-c", command) !!)
     _ <- logger.info(s"$command has been run")
   } yield output
 
@@ -30,7 +30,7 @@ object BashCommands {
     } { outStream =>
       IO(outStream.close()).handleErrorWith(_ => IO.unit)
     }.use(fos =>
-      IO.pure(fos.write(output.getBytes(Charset.forName("UTF-8")))))
+      IO(fos.write(output.getBytes(Charset.forName("UTF-8")))))
 
   def apply()(implicit logger: SelfAwareStructuredLogger[IO]): BashCommands = new BashCommands(outputToFile)(logger)
 }

--- a/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/BashCommandsSpec.scala
+++ b/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/BashCommandsSpec.scala
@@ -13,7 +13,7 @@ class BashCommandsSpec extends ExportSpec {
 
   "the runCommand method" should "throw an error for a failed command" in {
     val exception = intercept[RuntimeException] {
-      BashCommands().runCommand("invalidcommand").attempt.unsafeRunSync()
+      BashCommands().runCommand("invalidcommand").unsafeRunSync()
     }
     exception.getMessage should equal("Nonzero exit value: 127")
   }

--- a/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/BashCommandsSpec.scala
+++ b/exporter/src/test/scala/uk/gov/nationalarchives/consignmentexport/BashCommandsSpec.scala
@@ -22,7 +22,7 @@ class BashCommandsSpec extends ExportSpec {
     val fileWriterMock: (String, File) => IO[Unit] = mock[(String, File) => IO[Unit]]
     val commandCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     val fileCaptor: ArgumentCaptor[File] = ArgumentCaptor.forClass(classOf[File])
-    doAnswer(() => IO.pure(())).when(fileWriterMock).apply(commandCaptor.capture(), fileCaptor.capture())
+    doAnswer(() => IO.unit).when(fileWriterMock).apply(commandCaptor.capture(), fileCaptor.capture())
     new BashCommands(fileWriterMock).runCommandToFile("echo 'hello'", new File("test")).unsafeRunSync()
     commandCaptor.getValue should equal("hello\n")
     fileCaptor.getValue.getName should equal("test")


### PR DESCRIPTION
`IO.pure` is a way of returning an already-evaluated or hard-coded response. It shouldn't be used for real IO operations, because it is evaluated immediately rather than in the main IO evaluation step.

https://typelevel.org/cats-effect/datatypes/io.html#pure-values--iopure--iounit