### PR TITLE
Bump version number

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.7-SNAPSHOT"
+version in ThisBuild := "0.0.8-SNAPSHOT"


### PR DESCRIPTION
Version numbers out of sync due to Jenkins restart

Manually bump version to force push of new image to ECR