### PR TITLE
Send task heartbeat

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   private val monovoreDeclineVersion = "1.3.0"
 
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.19"
-  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.10"
+  lazy val awsUtils =  "uk.gov.nationalarchives.aws.utils" %% "tdr-aws-utils" % "0.1.18"
   lazy val bagit = "gov.loc" % "bagit" % "5.2.0"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "2.2.0"
   lazy val decline = "com.monovore" %% "decline" % monovoreDeclineVersion

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/StepFunction.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/StepFunction.scala
@@ -6,7 +6,7 @@ import cats.effect.IO
 import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
 import io.circe.generic.auto._
 import io.circe.syntax._
-import software.amazon.awssdk.services.sfn.model.{SendTaskFailureResponse, SendTaskSuccessResponse}
+import software.amazon.awssdk.services.sfn.model.{SendTaskFailureResponse, SendTaskHeartbeatResponse, SendTaskSuccessResponse}
 import uk.gov.nationalarchives.aws.utils.StepFunctionUtils
 import uk.gov.nationalarchives.consignmentexport.StepFunction.ExportOutput
 
@@ -17,6 +17,9 @@ class StepFunction(stepFunctionUtils: StepFunctionUtils)(implicit val logger: Se
 
   def publishFailure(taskToken: String, cause: String): IO[SendTaskFailureResponse] =
     stepFunctionUtils.sendTaskFailureRequest(taskToken, cause)
+
+  def sendHeartbeat(taskToken: String): IO[SendTaskHeartbeatResponse] =
+    stepFunctionUtils.sendTaskHeartbeat(taskToken)
 }
 
 object StepFunction {

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/MainSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/MainSpec.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent
 import org.apache.commons.codec.digest.DigestUtils
+import org.scalatest.Assertion
 import uk.gov.nationalarchives.consignmentexport.Utils.PathUtils
 
 import scala.io.Source
@@ -27,8 +28,7 @@ class MainSpec extends ExternalServiceSpec {
     putFile(s"$consignmentId/$fileId")
 
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
-
-    checkStepFunctionPublishCalled("publish_success_request_body")
+    checkStepFunctionSuccessCalled
     val objects = outputBucketObjects().map(_.key())
 
     objects.size should equal(2)
@@ -47,7 +47,7 @@ class MainSpec extends ExternalServiceSpec {
 
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
 
-    checkStepFunctionPublishCalled("publish_success_request_body")
+    checkStepFunctionSuccessCalled
 
     val downloadDirectory = s"$scratchDirectory/download"
     new File(s"$downloadDirectory").mkdirs()
@@ -76,7 +76,7 @@ class MainSpec extends ExternalServiceSpec {
     putFile(s"$consignmentId/$fileId")
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
 
-    checkStepFunctionPublishCalled("publish_success_request_body")
+    checkStepFunctionSuccessCalled
 
     val exportLocationEvent: Option[ServeEvent] = wiremockGraphqlServer.getAllServeEvents.asScala
       .find(p => p.getRequest.getBodyAsString.contains("mutation updateExportLocation"))
@@ -98,7 +98,7 @@ class MainSpec extends ExternalServiceSpec {
       Main.run(List("export", "--consignmentId", consignmentId, "--taskToken", taskTokenValue)).unsafeRunSync()
     }
 
-    checkStepFunctionPublishCalled("publish_failure_no_files_for_consignment_request_body")
+    checkStepFunctionFailureCalled("publish_failure_no_files_for_consignment_request_body")
     ex.getMessage should equal(s"Consignment API returned no files for consignment $consignmentId")
   }
 
@@ -116,7 +116,7 @@ class MainSpec extends ExternalServiceSpec {
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
     }
 
-    checkStepFunctionPublishCalled("publish_failure_incomplete_file_properties_request_body")
+    checkStepFunctionFailureCalled("publish_failure_incomplete_file_properties_request_body")
     ex.getMessage should equal(s"$fileId is missing the following properties: foiExemptionCode, heldBy, language, rightsCopyright, sha256ClientSideChecksum")
   }
 
@@ -134,7 +134,7 @@ class MainSpec extends ExternalServiceSpec {
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
     }
 
-    checkStepFunctionPublishCalled("publish_failure_missing_ffid_metadata_request_body")
+    checkStepFunctionFailureCalled("publish_failure_missing_ffid_metadata_request_body")
     ex.getMessage should equal(s"FFID metadata is missing for file id $fileId")
   }
 
@@ -152,7 +152,7 @@ class MainSpec extends ExternalServiceSpec {
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
     }
 
-    checkStepFunctionPublishCalled("publish_failure_missing_antivirus_metadata_request_body")
+    checkStepFunctionFailureCalled("publish_failure_missing_antivirus_metadata_request_body")
     ex.getMessage should equal(s"Antivirus metadata is missing for file id $fileId")
   }
 
@@ -167,7 +167,7 @@ class MainSpec extends ExternalServiceSpec {
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
     }
 
-    checkStepFunctionPublishCalled("publish_failure_no_consignment_metadata_request_body")
+    checkStepFunctionFailureCalled("publish_failure_no_consignment_metadata_request_body")
     ex.getMessage should equal(s"No consignment metadata found for consignment $consignmentId")
   }
 
@@ -184,7 +184,7 @@ class MainSpec extends ExternalServiceSpec {
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
     }
 
-    checkStepFunctionPublishCalled("publish_failure_no_valid_user_request_body")
+    checkStepFunctionFailureCalled("publish_failure_no_valid_user_request_body")
     ex.getMessage should equal(s"No valid user found $keycloakUserId: HTTP 404 Not Found")
   }
 
@@ -202,7 +202,7 @@ class MainSpec extends ExternalServiceSpec {
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
     }
 
-    checkStepFunctionPublishCalled("publish_failure_incomplete_user_request_body")
+    checkStepFunctionFailureCalled("publish_failure_incomplete_user_request_body")
     ex.getMessage should equal(s"Incomplete details for user $keycloakUserId")
   }
 
@@ -220,7 +220,7 @@ class MainSpec extends ExternalServiceSpec {
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
     }
 
-    checkStepFunctionPublishCalled("publish_failure_checksum_mismatch_request_body")
+    checkStepFunctionFailureCalled("publish_failure_checksum_mismatch_request_body")
     ex.getMessage should equal(s"Checksum mismatch for file(s): $fileId")
   }
 
@@ -230,15 +230,17 @@ class MainSpec extends ExternalServiceSpec {
     stepFunctionPublish
   }
 
-  private def checkStepFunctionPublishCalled(expectedJsonRequestFilePath: String) = {
-    wiremockSfnServer.getAllServeEvents.size() should be(1)
-    val expectedRequestBody: String = getExpectedResponseAsString(s"json/${expectedJsonRequestFilePath}.json")
+  private def checkStepFunctionSuccessCalled: Assertion =
+    checkStepFunctionPublishCalled("publish_success_request_body", "SendTaskSuccess")
+
+  private def checkStepFunctionFailureCalled(expectedJsonRequestFilePath: String) =
+    checkStepFunctionPublishCalled(expectedJsonRequestFilePath, "SendTaskFailure")
+
+  private def checkStepFunctionPublishCalled(expectedJsonRequestFilePath: String, method: String) = {
+    wiremockSfnServer.getAllServeEvents.asScala
+      .count(ev => ev.getRequest.getHeader("X-Amz-Target") == s"AWSStepFunctions.$method") should equal(1)
+    val expectedRequestBody: String = fromResource(s"json/$expectedJsonRequestFilePath.json").mkString.replaceAll("\n", "")
     val eventRequestBody = wiremockSfnServer.getAllServeEvents.get(0).getRequest.getBodyAsString
     eventRequestBody should equal(expectedRequestBody)
-  }
-
-  private def getExpectedResponseAsString(filePath: String) = {
-    //Strip new lines from json file
-    fromResource(filePath).mkString.replaceAll("\n", "")
   }
 }


### PR DESCRIPTION
This makes a call to SendTaskHeartbeat every minute. This works by creating a new [cats-effect fiber](https://typelevel.org/cats-effect/docs/2.x/datatypes/fiber) on the call to `runHeartbeat().start` This runs asynchronously to the main thread and then is cancelled at the end just to keep things tidy although it would be killed anyway when the main process exits.

The tests have had to be changed because we're now making to separate calls the step function wiremock endpoint. These are distinguished by the `X-Amz-Target` header so we check for that when we're looking at API calls. I've also added in a test to show that we are calling the heartbeat endpoint.
