### PR TITLE
Add extra logging to the sendHeartbeat method.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/StepFunction.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/StepFunction.scala
@@ -18,8 +18,11 @@ class StepFunction(stepFunctionUtils: StepFunctionUtils)(implicit val logger: Se
   def publishFailure(taskToken: String, cause: String): IO[SendTaskFailureResponse] =
     stepFunctionUtils.sendTaskFailureRequest(taskToken, cause)
 
-  def sendHeartbeat(taskToken: String): IO[SendTaskHeartbeatResponse] =
-    stepFunctionUtils.sendTaskHeartbeat(taskToken)
+  def sendHeartbeat(taskToken: String): IO[Unit] =
+    stepFunctionUtils.sendTaskHeartbeat(taskToken).attempt.flatMap {
+      case Left(err) => logger.error(err)("Error sending the task heartbeat")
+      case Right(_) => logger.info(s"Task heartbeat sent successfully")
+    }
 }
 
 object StepFunction {


### PR DESCRIPTION
I'm not completely sure why but somewhere between the async thread this
runs in and the async response from the AWS SDK, any errors are ignored
in the main thread.
Calling attempt and then logging based on the value of the either will
log if there are any problems sending the heartbeat.
