### PR TITLE
Manual version bump to v22.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.21-SNAPSHOT"
+version in ThisBuild := "0.0.22-SNAPSHOT"


### PR DESCRIPTION
I merged new changes to the export and the version bump PR in the wrong
order so now not only is the version out of date, the changes that
should have gone to prod haven't because the release step was skipped
because the most recent PR was the auto version bump one. Once this is
merged, all the recent changes should be on prod and the versions should
be up to date.
