### PR TITLE
Add 'consignment type' value to output message

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -81,7 +81,8 @@ object Main extends CommandIOApp("tdr-consignment-export", "Exports tdr files in
             ExportOutput(consignmentData.userid,
               bagMetadata.get(InternalSenderIdentifierKey).get(0),
               bagMetadata.get(SourceOrganisationKey).get(0),
-              consignmentType
+              consignmentType,
+              s3Bucket
             ))
           _ <- heartbeat.cancel
         } yield ExitCode.Success

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -73,13 +73,16 @@ object Main extends CommandIOApp("tdr-consignment-export", "Exports tdr files in
           tarPath = s"$basePath/$consignmentReference.tar.gz"
           _ <- bashCommands.runCommand(s"tar --sort=name --owner=root:0 --group=root:0 --mtime ${java.time.LocalDate.now.toString} -C $basePath -c ./${consignmentData.consignmentReference} | gzip -n > $tarPath")
           _ <- bashCommands.runCommand(s"sha256sum $tarPath > $tarPath.sha256")
-          s3Bucket = if(consignmentData.consignmentType.contains("judgment")) { config.s3.outputBucketJudgment } else { config.s3.outputBucket}
+          consignmentType = consignmentData.consignmentType.getOrElse("standard")
+          s3Bucket = if(consignmentType.contains("judgment")) { config.s3.outputBucketJudgment } else { config.s3.outputBucket}
           _ <- s3Files.uploadFiles(s3Bucket, consignmentId, consignmentReference, tarPath)
           _ <- graphQlApi.updateExportLocation(config, consignmentId, s"s3://$s3Bucket/$consignmentReference.tar.gz", exportDatetime)
           _ <- stepFunction.publishSuccess(taskToken,
             ExportOutput(consignmentData.userid,
               bagMetadata.get(InternalSenderIdentifierKey).get(0),
-              bagMetadata.get(SourceOrganisationKey).get(0)))
+              bagMetadata.get(SourceOrganisationKey).get(0),
+              consignmentType
+            ))
           _ <- heartbeat.cancel
         } yield ExitCode.Success
 

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/StepFunction.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/StepFunction.scala
@@ -30,5 +30,5 @@ object StepFunction {
   def apply(stepFunctionUtils: StepFunctionUtils)
            (implicit logger: SelfAwareStructuredLogger[IO]): StepFunction = new StepFunction(stepFunctionUtils)(logger)
 
-  case class ExportOutput(userId: UUID, consignmentReference: String, transferringBodyName: String)
+  case class ExportOutput(userId: UUID, consignmentReference: String, transferringBodyName: String, consignmentType: String)
 }

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/StepFunction.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/StepFunction.scala
@@ -30,5 +30,5 @@ object StepFunction {
   def apply(stepFunctionUtils: StepFunctionUtils)
            (implicit logger: SelfAwareStructuredLogger[IO]): StepFunction = new StepFunction(stepFunctionUtils)(logger)
 
-  case class ExportOutput(userId: UUID, consignmentReference: String, transferringBodyName: String, consignmentType: String)
+  case class ExportOutput(userId: UUID, consignmentReference: String, transferringBodyName: String, consignmentType: String, exportBucket: String)
 }

--- a/src/test/resources/json/publish_judgment_success_request_body.json
+++ b/src/test/resources/json/publish_judgment_success_request_body.json
@@ -1,0 +1,1 @@
+{"taskToken":"taskToken1234","output":"{\n  \"userId\" : \"b2657adf-6e93-424f-b0f1-aadd26762a96\",\n  \"consignmentReference\" : \"consignmentReference-1234\",\n  \"transferringBodyName\" : \"MOCK1 Department\",\n  \"consignmentType\" : \"judgment\"\n}"}

--- a/src/test/resources/json/publish_judgment_success_request_body.json
+++ b/src/test/resources/json/publish_judgment_success_request_body.json
@@ -1,1 +1,1 @@
-{"taskToken":"taskToken1234","output":"{\n  \"userId\" : \"b2657adf-6e93-424f-b0f1-aadd26762a96\",\n  \"consignmentReference\" : \"consignmentReference-1234\",\n  \"transferringBodyName\" : \"MOCK1 Department\",\n  \"consignmentType\" : \"judgment\"\n}"}
+{"taskToken":"taskToken1234","output":"{\n  \"userId\" : \"b2657adf-6e93-424f-b0f1-aadd26762a96\",\n  \"consignmentReference\" : \"consignmentReference-1234\",\n  \"transferringBodyName\" : \"MOCK1 Department\",\n  \"consignmentType\" : \"judgment\",\n  \"exportBucket\" : \"test-output-bucket-judgment\"\n}"}

--- a/src/test/resources/json/publish_success_request_body.json
+++ b/src/test/resources/json/publish_success_request_body.json
@@ -1,1 +1,1 @@
-{"taskToken":"taskToken1234","output":"{\n  \"userId\" : \"b2657adf-6e93-424f-b0f1-aadd26762a96\",\n  \"consignmentReference\" : \"consignmentReference-1234\",\n  \"transferringBodyName\" : \"MOCK1 Department\",\n  \"consignmentType\" : \"standard\"\n}"}
+{"taskToken":"taskToken1234","output":"{\n  \"userId\" : \"b2657adf-6e93-424f-b0f1-aadd26762a96\",\n  \"consignmentReference\" : \"consignmentReference-1234\",\n  \"transferringBodyName\" : \"MOCK1 Department\",\n  \"consignmentType\" : \"standard\",\n  \"exportBucket\" : \"test-output-bucket\"\n}"}

--- a/src/test/resources/json/publish_success_request_body.json
+++ b/src/test/resources/json/publish_success_request_body.json
@@ -1,1 +1,1 @@
-{"taskToken":"taskToken1234","output":"{\n  \"userId\" : \"b2657adf-6e93-424f-b0f1-aadd26762a96\",\n  \"consignmentReference\" : \"consignmentReference-1234\",\n  \"transferringBodyName\" : \"MOCK1 Department\"\n}"}
+{"taskToken":"taskToken1234","output":"{\n  \"userId\" : \"b2657adf-6e93-424f-b0f1-aadd26762a96\",\n  \"consignmentReference\" : \"consignmentReference-1234\",\n  \"transferringBodyName\" : \"MOCK1 Department\",\n  \"consignmentType\" : \"standard\"\n}"}

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/MainSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/MainSpec.scala
@@ -29,7 +29,7 @@ class MainSpec extends ExternalServiceSpec {
     putFile(s"$consignmentId/$fileId")
 
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
-    checkStepFunctionSuccessCalled
+    checkStepFunctionSuccessCalled()
     val objects = outputBucketObjects(standardOutputBucket).map(_.key())
 
     objects.size should equal(2)
@@ -47,7 +47,7 @@ class MainSpec extends ExternalServiceSpec {
     putFile(s"$consignmentId/$fileId")
 
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
-    checkStepFunctionSuccessCalled
+    checkStepFunctionSuccessCalled("publish_judgment_success_request_body")
     val objects = outputBucketObjects(judgmentOutputBucket).map(_.key())
 
     objects.size should equal(2)
@@ -66,7 +66,7 @@ class MainSpec extends ExternalServiceSpec {
 
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
 
-    checkStepFunctionSuccessCalled
+    checkStepFunctionSuccessCalled()
 
     val downloadDirectory = s"$scratchDirectory/download"
     new File(s"$downloadDirectory").mkdirs()
@@ -96,7 +96,7 @@ class MainSpec extends ExternalServiceSpec {
 
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
 
-    checkStepFunctionSuccessCalled
+    checkStepFunctionSuccessCalled("publish_judgment_success_request_body")
 
     val downloadDirectory = s"$scratchDirectory/download"
     new File(s"$downloadDirectory").mkdirs()
@@ -125,7 +125,7 @@ class MainSpec extends ExternalServiceSpec {
     putFile(s"$consignmentId/$fileId")
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
 
-    checkStepFunctionSuccessCalled
+    checkStepFunctionSuccessCalled()
 
     val exportLocationEvent: Option[ServeEvent] = wiremockGraphqlServer.getAllServeEvents.asScala
       .find(p => p.getRequest.getBodyAsString.contains("mutation updateExportLocation"))
@@ -146,7 +146,7 @@ class MainSpec extends ExternalServiceSpec {
     putFile(s"$consignmentId/$fileId")
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", taskTokenValue)).unsafeRunSync()
 
-    checkStepFunctionSuccessCalled
+    checkStepFunctionSuccessCalled("publish_judgment_success_request_body")
 
     val exportLocationEvent: Option[ServeEvent] = wiremockGraphqlServer.getAllServeEvents.asScala
       .find(p => p.getRequest.getBodyAsString.contains("mutation updateExportLocation"))
@@ -439,8 +439,8 @@ class MainSpec extends ExternalServiceSpec {
     stepFunctionPublish
   }
 
-  private def checkStepFunctionSuccessCalled: Assertion =
-    checkStepFunctionPublishCalled("publish_success_request_body", "SendTaskSuccess")
+  private def checkStepFunctionSuccessCalled(expectedJsonPath: String = "publish_success_request_body"): Assertion =
+    checkStepFunctionPublishCalled(expectedJsonPath, "SendTaskSuccess")
 
   private def checkStepFunctionFailureCalled(expectedJsonRequestFilePath: String) =
     checkStepFunctionPublishCalled(expectedJsonRequestFilePath, "SendTaskFailure")

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/StepFunctionSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/StepFunctionSpec.scala
@@ -23,7 +23,7 @@ class StepFunctionSpec extends ExportSpec {
     doAnswer(() => mockResponse).when(sfnUtils).sendTaskSuccessRequest(taskTokenCaptor.capture(), exportOutputCaptor.capture())
 
     val taskToken = "taskToken1234"
-    val exportOutput = ExportOutput(UUID.randomUUID(), "consignmentReference", "tb-name")
+    val exportOutput = ExportOutput(UUID.randomUUID(), "consignmentReference", "tb-name", "standard")
 
     StepFunction(sfnUtils).publishSuccess(taskToken, exportOutput).unsafeRunSync()
     taskTokenCaptor.getValue should equal(taskToken)

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/StepFunctionSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/StepFunctionSpec.scala
@@ -23,7 +23,7 @@ class StepFunctionSpec extends ExportSpec {
     doAnswer(() => mockResponse).when(sfnUtils).sendTaskSuccessRequest(taskTokenCaptor.capture(), exportOutputCaptor.capture())
 
     val taskToken = "taskToken1234"
-    val exportOutput = ExportOutput(UUID.randomUUID(), "consignmentReference", "tb-name", "standard")
+    val exportOutput = ExportOutput(UUID.randomUUID(), "consignmentReference", "tb-name", "standard", "judgments3ExportBucket")
 
     StepFunction(sfnUtils).publishSuccess(taskToken, exportOutput).unsafeRunSync()
     taskTokenCaptor.getValue should equal(taskToken)


### PR DESCRIPTION
For notifying transform engine that a package is ready require the 'consignment type' to select the correct s3 bucket