### PR TITLE
Temporarily add sleep for downloading files

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
@@ -26,8 +26,8 @@ class S3Files(s3Utils: S3Utils)(implicit val logger: SelfAwareStructuredLogger[I
   def downloadFiles(files: List[ValidatedFileMetadata], bucket: String, consignmentId: UUID, consignmentReference: String, rootLocation: String): IO[Unit] = for {
     _ <- createDownloadDirectories(files, consignmentReference, rootLocation)
     _ <- files.filter(_.fileType != directoryType).map(file => {
-      IO.sleep(100 milliseconds)
-      s3Utils.downloadFiles(bucket, s"$consignmentId/${file.fileId}", s"$rootLocation/$consignmentReference/${file.clientSideOriginalFilePath}".toPath.some)
+      IO.sleep(100 milliseconds).flatMap(_ =>
+        s3Utils.downloadFiles(bucket, s"$consignmentId/${file.fileId}", s"$rootLocation/$consignmentReference/${file.clientSideOriginalFilePath}".toPath.some))
     }).sequence
     _ <- logger.info(s"Files downloaded from S3 for consignment $consignmentId")
   } yield ()

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
@@ -10,6 +10,7 @@ import uk.gov.nationalarchives.aws.utils.S3Utils
 import uk.gov.nationalarchives.consignmentexport.Main.directoryType
 import uk.gov.nationalarchives.consignmentexport.Utils._
 import uk.gov.nationalarchives.consignmentexport.Validator.ValidatedFileMetadata
+import scala.concurrent.duration._
 
 import scala.language.postfixOps
 
@@ -25,6 +26,7 @@ class S3Files(s3Utils: S3Utils)(implicit val logger: SelfAwareStructuredLogger[I
   def downloadFiles(files: List[ValidatedFileMetadata], bucket: String, consignmentId: UUID, consignmentReference: String, rootLocation: String): IO[Unit] = for {
     _ <- createDownloadDirectories(files, consignmentReference, rootLocation)
     _ <- files.filter(_.fileType != directoryType).map(file => {
+      IO.sleep(100 milliseconds)
       s3Utils.downloadFiles(bucket, s"$consignmentId/${file.fileId}", s"$rootLocation/$consignmentReference/${file.clientSideOriginalFilePath}".toPath.some)
     }).sequence
     _ <- logger.info(s"Files downloaded from S3 for consignment $consignmentId")


### PR DESCRIPTION
Export for consignments with a large number of files are failing

Appears to be an issue with downloading the files from s3

Temporarily add a sleep between downloading each file to confirm this is what is causing the failure