### PR TITLE
Download files in batches to even out s3 requests

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -6,6 +6,10 @@ s3 {
   outputBucketJudgment = "tdr-consignment-export-judgment-intg"
   outputBucketJudgment = ${?OUTPUT_BUCKET_JUDGMENT}
   endpoint = "https://s3.eu-west-2.amazonaws.com/"
+  downloadFilesBatchSize = 40
+  downloadFilesBatchSize = ${?DOWNLOAD_FILES_BATCH_SIZE}
+  downloadBatchDelayMs = 10
+  downloadBatchDelayMs = ${?DOWNLOAD_BATCH_DELAY_MS}
 }
 api {
   url = "https://api.tdr-integration.nationalarchives.gov.uk/graphql"

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/Config.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/Config.scala
@@ -8,7 +8,8 @@ import pureconfig.{CamelCase, ConfigFieldMapping, ConfigSource}
 
 object Config {
 
-  case class S3(endpoint: String, cleanBucket: String, outputBucket: String, outputBucketJudgment: String)
+  case class S3(endpoint: String, cleanBucket: String, outputBucket: String, outputBucketJudgment: String,
+                downloadFilesBatchSize: Int, downloadBatchDelayMs: Int)
   case class Api(url: String)
   case class Auth(url: String, clientId: String, clientSecret: String, realm: String)
   case class EFS(rootLocation: String)

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -45,7 +45,7 @@ object Main extends CommandIOApp("tdr-consignment-export", "Exports tdr files in
           bashCommands = BashCommands()
           graphQlApi = GraphQlApi(config.api.url)
           keycloakClient = KeycloakClient(config)
-          s3Files = S3Files(S3Utils(s3Async))
+          s3Files = S3Files(S3Utils(s3Async), config)
           bagit = Bagit()
           validator = Validator(consignmentId)
           //Export datetime generated as value needed in bag metadata and DB table

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
@@ -5,32 +5,47 @@ import java.util.UUID
 
 import cats.effect.IO
 import cats.implicits._
+import com.typesafe.config.ConfigFactory
 import org.typelevel.log4cats.SelfAwareStructuredLogger
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import uk.gov.nationalarchives.aws.utils.S3Utils
 import uk.gov.nationalarchives.consignmentexport.Main.directoryType
 import uk.gov.nationalarchives.consignmentexport.Utils._
 import uk.gov.nationalarchives.consignmentexport.Validator.ValidatedFileMetadata
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class S3Files(s3Utils: S3Utils)(implicit val logger: SelfAwareStructuredLogger[IO]) {
+  private val configuration = ConfigFactory.load()
+  private val downloadBatchSize = configuration.getInt("s3.downloadFilesBatchSize")
+  private val downloadDelay = configuration.getInt("s3.downloadBatchDelayMs")
 
-  def createDownloadDirectories(files: List[ValidatedFileMetadata], consignmentReference: String, rootLocation: String) = {
+  def createDownloadDirectories(files: List[ValidatedFileMetadata], consignmentReference: String, rootLocation: String): IO[List[Boolean]] = {
     IO {
       new File(s"$rootLocation/$consignmentReference").mkdirs()
       files.filter(_.fileType == "Folder").map(f => new File(s"$rootLocation/$consignmentReference/${f.clientSideOriginalFilePath}").mkdirs())
     }
   }
 
-  def downloadFiles(files: List[ValidatedFileMetadata], bucket: String, consignmentId: UUID, consignmentReference: String, rootLocation: String): IO[Unit] = for {
-    _ <- createDownloadDirectories(files, consignmentReference, rootLocation)
-    _ <- files.filter(_.fileType != directoryType).map(file => {
-      IO.sleep(100 milliseconds).flatMap(_ =>
-        s3Utils.downloadFiles(bucket, s"$consignmentId/${file.fileId}", s"$rootLocation/$consignmentReference/${file.clientSideOriginalFilePath}".toPath.some))
-    }).sequence
-    _ <- logger.info(s"Files downloaded from S3 for consignment $consignmentId")
-  } yield ()
+  def batchDownloadingFiles(batch: List[ValidatedFileMetadata], bucket: String, consignmentId: UUID, consignmentReference: String, rootLocation: String): IO[List[GetObjectResponse]] = {
+    IO.sleep(downloadDelay milliseconds).flatMap(_ => {
+      batch.map(file =>
+        s3Utils.downloadFiles(
+          bucket,
+          s"$consignmentId/${file.fileId}",
+          s"$rootLocation/$consignmentReference/${file.clientSideOriginalFilePath}".toPath.some
+        )).sequence
+    })
+  }
+
+  def downloadFiles(files: List[ValidatedFileMetadata], bucket: String, consignmentId: UUID, consignmentReference: String, rootLocation: String): IO[Unit] = {
+    for {
+      _ <- createDownloadDirectories(files, consignmentReference, rootLocation)
+      _ <- files.filter(_.fileType != directoryType).grouped(downloadBatchSize).toSeq.map(batchDownloadingFiles(_, bucket, consignmentId, consignmentReference, rootLocation)).sequence
+      _ <- logger.info(s"Files downloaded from S3 for consignment $consignmentId")
+    } yield()
+  }
 
   def uploadFiles(bucket: String, consignmentId: UUID, consignmentReference: String, tarPath: String): IO[Unit] = for {
     _ <- s3Utils.upload(bucket, s"$consignmentReference.tar.gz", tarPath.toPath)

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 
 import cats.effect.IO
 import cats.implicits._
-import com.typesafe.config.ConfigFactory
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import uk.gov.nationalarchives.aws.utils.S3Utils

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/S3Files.scala
@@ -9,6 +9,7 @@ import com.typesafe.config.ConfigFactory
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import uk.gov.nationalarchives.aws.utils.S3Utils
+import uk.gov.nationalarchives.consignmentexport.Config.Configuration
 import uk.gov.nationalarchives.consignmentexport.Main.directoryType
 import uk.gov.nationalarchives.consignmentexport.Utils._
 import uk.gov.nationalarchives.consignmentexport.Validator.ValidatedFileMetadata
@@ -16,10 +17,9 @@ import uk.gov.nationalarchives.consignmentexport.Validator.ValidatedFileMetadata
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class S3Files(s3Utils: S3Utils)(implicit val logger: SelfAwareStructuredLogger[IO]) {
-  private val configuration = ConfigFactory.load()
-  private val downloadBatchSize = configuration.getInt("s3.downloadFilesBatchSize")
-  private val downloadDelay = configuration.getInt("s3.downloadBatchDelayMs")
+class S3Files(s3Utils: S3Utils, config: Configuration)(implicit val logger: SelfAwareStructuredLogger[IO]) {
+  private val downloadBatchSize = config.s3.downloadFilesBatchSize
+  private val downloadDelay = config.s3.downloadBatchDelayMs
 
   def createDownloadDirectories(files: List[ValidatedFileMetadata], consignmentReference: String, rootLocation: String): IO[List[Boolean]] = {
     IO {
@@ -55,5 +55,5 @@ class S3Files(s3Utils: S3Utils)(implicit val logger: SelfAwareStructuredLogger[I
 }
 
 object S3Files {
-  def apply(s3Utils: S3Utils)(implicit logger: SelfAwareStructuredLogger[IO]): S3Files = new S3Files(s3Utils)(logger)
+  def apply(s3Utils: S3Utils, config: Configuration)(implicit logger: SelfAwareStructuredLogger[IO]): S3Files = new S3Files(s3Utils, config)(logger)
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -3,6 +3,8 @@ s3 {
     outputBucket = "test-output-bucket"
     outputBucketJudgment = "test-output-bucket-judgment"
     endpoint = "http://localhost:8003/"
+    downloadFilesBatchSize = 1
+    downloadBatchDelayMs = 0
 }
 
 efs {

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/GraphQlApiSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/GraphQlApiSpec.scala
@@ -28,7 +28,7 @@ class GraphQlApiSpec extends ExportSpec {
   private val fixedDateTime = ZonedDateTime.now()
 
   val config: Configuration = Configuration(
-    S3("", "", "", ""),
+    S3("", "", "", "", 0, 0),
     Api(""),
     Auth("authUrl", "clientId", "clientSecret", "realm"),
     EFS(""),

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/KeycloakClientSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/KeycloakClientSpec.scala
@@ -4,7 +4,7 @@ import uk.gov.nationalarchives.consignmentexport.Config._
 
 class KeycloakClientSpec extends ExternalServiceSpec {
   private val config = Configuration(
-    S3("", "", "", ""),
+    S3("", "", "", "", 0, 0),
     Api(""),
     Auth("http://localhost:9002/auth", "tdr-backend-checks", "client-secret", "tdr"),
     EFS(""),

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/S3FilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/S3FilesSpec.scala
@@ -35,7 +35,7 @@ class S3FilesSpec extends ExportSpec {
     val fileId = UUID.randomUUID()
     val metadata = ValidatedFileMetadata(
       fileId,
-      "name",
+      "name1",
       "File",
       1L.some,
       LocalDateTime.now().some,
@@ -47,6 +47,7 @@ class S3FilesSpec extends ExportSpec {
       "rightsCopyright".some,
       "clientSideChecksumValue".some
     )
+
     val validatedMetadata = List(metadata)
 
     S3Files(s3Utils, config).downloadFiles(validatedMetadata, "testbucket", consignmentId, consignmentReference, "root").unsafeRunSync()
@@ -86,6 +87,34 @@ class S3FilesSpec extends ExportSpec {
 
     pathCaptor.getValue.isDefined should equal(true)
     pathCaptor.getValue.get.toString should equal(s"""root/$consignmentReference/a/path'with/quotes"""")
+  }
+
+  "the downloadFiles method" should "call the library method for each file" in {
+    val s3Utils = mock[S3Utils]
+    val bucketCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+    val keyCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+    val pathCaptor: ArgumentCaptor[Option[Path]] = ArgumentCaptor.forClass(classOf[Option[Path]])
+    val mockResponse = IO.pure(GetObjectResponse.builder.build())
+    doAnswer(() => mockResponse).when(s3Utils).downloadFiles(bucketCaptor.capture(), keyCaptor.capture(), pathCaptor.capture())
+
+    val consignmentId = UUID.randomUUID()
+    val consignmentReference = "Consignment-Reference"
+    val fileId1 = UUID.randomUUID()
+    val fileId2 = UUID.randomUUID()
+    val metadata1 = ValidatedFileMetadata(
+      fileId1, "name1", "File", 1L.some, LocalDateTime.now().some, "originalPath", "foiExemption".some, "heldBy".some,
+      "language".some, "legalStatus".some, "rightsCopyright".some, "clientSideChecksumValue".some
+    )
+    val metadata2 = ValidatedFileMetadata(
+      fileId2, "name2", "File", 1L.some, LocalDateTime.now().some, "originalPath", "foiExemption".some, "heldBy".some,
+      "language".some, "legalStatus".some, "rightsCopyright".some, "clientSideChecksumValue".some
+    )
+
+    val validatedMetadata = List(metadata1, metadata2)
+
+    S3Files(s3Utils, config).downloadFiles(validatedMetadata, "testbucket", consignmentId, consignmentReference, "root").unsafeRunSync()
+
+    verify(s3Utils, times(2)).downloadFiles(any[String], any[String], any[Option[Path]])
   }
 
   "the uploadFiles method" should "call the library method with the correct arguments" in {

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/S3FilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/S3FilesSpec.scala
@@ -11,8 +11,16 @@ import software.amazon.awssdk.services.s3.model.{GetObjectResponse, PutObjectRes
 import uk.gov.nationalarchives.aws.utils.S3Utils
 import uk.gov.nationalarchives.consignmentexport.Validator.ValidatedFileMetadata
 import cats.effect.unsafe.implicits.global
+import uk.gov.nationalarchives.consignmentexport.Config._
 
 class S3FilesSpec extends ExportSpec {
+  private val config = Configuration(
+    S3("", "", "", "", 1, 0),
+    Api(""),
+    Auth("http://localhost:9002/auth", "tdr-backend-checks", "client-secret", "tdr"),
+    EFS(""),
+    StepFunction("")
+  )
 
   "the downloadFiles method" should "call the library method with the correct arguments" in {
     val s3Utils = mock[S3Utils]
@@ -41,7 +49,7 @@ class S3FilesSpec extends ExportSpec {
     )
     val validatedMetadata = List(metadata)
 
-    S3Files(s3Utils).downloadFiles(validatedMetadata, "testbucket", consignmentId, consignmentReference, "root").unsafeRunSync()
+    S3Files(s3Utils, config).downloadFiles(validatedMetadata, "testbucket", consignmentId, consignmentReference, "root").unsafeRunSync()
 
     bucketCaptor.getValue should equal("testbucket")
     keyCaptor.getValue should equal(s"$consignmentId/$fileId")
@@ -74,7 +82,7 @@ class S3FilesSpec extends ExportSpec {
     )
     val validatedMetadata = List(metadata)
 
-    S3Files(s3Utils).downloadFiles(validatedMetadata, "testbucket", consignmentId, consignmentReference, "root").unsafeRunSync()
+    S3Files(s3Utils, config).downloadFiles(validatedMetadata, "testbucket", consignmentId, consignmentReference, "root").unsafeRunSync()
 
     pathCaptor.getValue.isDefined should equal(true)
     pathCaptor.getValue.get.toString should equal(s"""root/$consignmentReference/a/path'with/quotes"""")
@@ -91,7 +99,7 @@ class S3FilesSpec extends ExportSpec {
     val consignmentId = UUID.randomUUID()
     val consignmentRef = "TDR-2020-C57B"
 
-    S3Files(s3Utils).uploadFiles("testbucket", consignmentId, consignmentRef, "fakepath").unsafeRunSync()
+    S3Files(s3Utils, config).uploadFiles("testbucket", consignmentId, consignmentRef, "fakepath").unsafeRunSync()
 
     bucketCaptor.getAllValues.forEach(b => b should equal("testbucket"))
     val keyValues = keyCaptor.getAllValues


### PR DESCRIPTION
Trying to download all the files for a large consignments uses up all the s3 connections causing the download to fail

Batching with a pause even outs the burst of request to s3. Pausing on batches is also quicker that pausing on each individual file download request