### PR TITLE
Changes for redacted files

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,14 +7,14 @@ object Dependencies {
   private val mockitoScalaVersion = "1.17.12"
   private val monovoreDeclineVersion = "2.3.0"
 
-  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.75"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.259-SNAPSHOT"
+  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.77"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.260"
   lazy val awsUtils =  "uk.gov.nationalarchives" %% "tdr-aws-utils" % "0.1.35"
   lazy val bagit = "gov.loc" % "bagit" % "5.2.0"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.3.14"
   lazy val decline = "com.monovore" %% "decline" % monovoreDeclineVersion
   lazy val declineEffect = "com.monovore" %% "decline-effect" % monovoreDeclineVersion
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.51"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.53"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.13"
   lazy val scalaCsv = "com.github.tototoshi" %% "scala-csv" % "1.3.10"
   lazy val log4cats = "org.typelevel" %% "log4cats-core" % log4CatsVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   private val monovoreDeclineVersion = "2.3.0"
 
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.75"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.258"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.259-SNAPSHOT"
   lazy val awsUtils =  "uk.gov.nationalarchives" %% "tdr-aws-utils" % "0.1.35"
   lazy val bagit = "gov.loc" % "bagit" % "5.2.0"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.3.14"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -16,7 +16,7 @@ api {
   url = ${?API_URL}
 }
 auth {
-  url = "https://auth.tdr-integration.nationalarchives.gov.uk/auth"
+  url = "https://auth.tdr-integration.nationalarchives.gov.uk"
   url = ${?AUTH_URL}
   clientId = "tdr-backend-checks"
   clientSecret = ${CLIENT_SECRET}

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
@@ -17,7 +17,7 @@ class BagAdditionalFiles(rootDirectory: Path) {
   }
 
   def createFileMetadataCsv(fileMetadataList: List[ValidatedFileMetadata]): IO[File] = {
-    val header = List("Filepath", "FileName", "FileType", "Filesize", "RightsCopyright", "LegalStatus", "HeldBy", "Language", "FoiExemptionCode", "LastModified", "OriginalVersionId")
+    val header = List("Filepath", "FileName", "FileType", "Filesize", "RightsCopyright", "LegalStatus", "HeldBy", "Language", "FoiExemptionCode", "LastModified", "OriginalVersionPath")
     val fileMetadataRows = fileMetadataList.map(f => List(
       dataPath(f.clientSideOriginalFilePath),
       f.fileName,

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
@@ -17,7 +17,7 @@ class BagAdditionalFiles(rootDirectory: Path) {
   }
 
   def createFileMetadataCsv(fileMetadataList: List[ValidatedFileMetadata]): IO[File] = {
-    val header = List("Filepath", "FileName", "FileType", "Filesize", "RightsCopyright", "LegalStatus", "HeldBy", "Language", "FoiExemptionCode", "LastModified")
+    val header = List("Filepath", "FileName", "FileType", "Filesize", "RightsCopyright", "LegalStatus", "HeldBy", "Language", "FoiExemptionCode", "LastModified", "OriginalVersionId")
     val fileMetadataRows = fileMetadataList.map(f => List(
       dataPath(f.clientSideOriginalFilePath),
       f.fileName,
@@ -29,6 +29,7 @@ class BagAdditionalFiles(rootDirectory: Path) {
       f.language.getOrElse(""),
       f.foiExemptionCode.getOrElse(""),
       f.clientSideLastModifiedDate.map(d => DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").format(d)).getOrElse(""),
+      f.originalFile.getOrElse("")
     )
     )
     writeToCsv("file-metadata.csv", header, fileMetadataRows)

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
@@ -17,7 +17,7 @@ class BagAdditionalFiles(rootDirectory: Path) {
   }
 
   def createFileMetadataCsv(fileMetadataList: List[ValidatedFileMetadata]): IO[File] = {
-    val header = List("Filepath", "FileName", "FileType", "Filesize", "RightsCopyright", "LegalStatus", "HeldBy", "Language", "FoiExemptionCode", "LastModified", "OriginalVersionPath")
+    val header = List("Filepath", "FileName", "FileType", "Filesize", "RightsCopyright", "LegalStatus", "HeldBy", "Language", "FoiExemptionCode", "LastModified", "OriginalFilePath")
     val fileMetadataRows = fileMetadataList.map(f => List(
       dataPath(f.clientSideOriginalFilePath),
       f.fileName,

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -36,7 +36,7 @@ object Main extends CommandIOApp("tdr-consignment-export", "Exports tdr files in
       case FileExport(consignmentId, taskToken) =>
         val exportFailedErrorMessage = s"Export for consignment $consignmentId failed"
         val stepFunction: StepFunction  = StepFunction(StepFunctionUtils(sfnAsyncClient(stepFunctionPublishEndpoint)))
-        def runHeartbeat(): IO[Unit] = IO.unit >> IO.sleep(30 seconds) >> runHeartbeat()
+        def runHeartbeat(): IO[Unit] = stepFunction.sendHeartbeat(taskToken) >> IO.sleep(30 seconds) >> runHeartbeat()
         val exitCode = for {
           heartbeat <- runHeartbeat().start
           config <- config()

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/Main.scala
@@ -36,7 +36,7 @@ object Main extends CommandIOApp("tdr-consignment-export", "Exports tdr files in
       case FileExport(consignmentId, taskToken) =>
         val exportFailedErrorMessage = s"Export for consignment $consignmentId failed"
         val stepFunction: StepFunction  = StepFunction(StepFunctionUtils(sfnAsyncClient(stepFunctionPublishEndpoint)))
-        def runHeartbeat(): IO[Unit] = stepFunction.sendHeartbeat(taskToken) >> IO.sleep(30 seconds) >> runHeartbeat()
+        def runHeartbeat(): IO[Unit] = IO.unit >> IO.sleep(30 seconds) >> runHeartbeat()
         val exitCode = for {
           heartbeat <- runHeartbeat().start
           config <- config()

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/Validator.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/Validator.scala
@@ -84,7 +84,8 @@ class Validator(consignmentId: UUID) {
     f.metadata.language,
     f.metadata.legalStatus,
     f.metadata.rightsCopyright,
-    f.metadata.sha256ClientSideChecksum
+    f.metadata.sha256ClientSideChecksum,
+    f.originalFilePath
   )
 
 }
@@ -110,7 +111,9 @@ object Validator {
                                    language: Option[String],
                                    legalStatus: Option[String],
                                    rightsCopyright: Option[String],
-                                   clientSideChecksum: Option[String])
+                                   clientSideChecksum: Option[String],
+                                   originalFile: Option[String]
+                                  )
 
   case class ValidatedAntivirusMetadata(filePath: String,
                                         software: String,

--- a/src/test/resources/json/get_consignment_for_export.json
+++ b/src/test/resources/json/get_consignment_for_export.json
@@ -18,7 +18,7 @@
           "fileId": "7b19b272-d4d1-4d77-bf25-511dc6489d12",
           "fileName": "name",
           "fileType": "File",
-          "originalFile": "cc5aa3d1-dd51-45bb-be48-44190ee8ad40",
+          "originalFilePath": "/original/file/path",
           "metadata": {
             "clientSideOriginalFilePath": "originalPath",
             "legalStatus": "Public Record",

--- a/src/test/resources/json/get_consignment_for_export.json
+++ b/src/test/resources/json/get_consignment_for_export.json
@@ -18,6 +18,7 @@
           "fileId": "7b19b272-d4d1-4d77-bf25-511dc6489d12",
           "fileName": "name",
           "fileType": "File",
+          "originalFile": "cc5aa3d1-dd51-45bb-be48-44190ee8ad40",
           "metadata": {
             "clientSideOriginalFilePath": "originalPath",
             "legalStatus": "Public Record",

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -46,7 +46,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalVersionId")
+    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalVersionPath")
     rest.length should equal(2)
     rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:30,$originalFilePath")
     rest.last should equal(s"data/folder,folderName,Folder,,,,,,,,")
@@ -78,7 +78,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalVersionId")
+    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalVersionPath")
     rest.length should equal(1)
     rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:00,")
     source.close()

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -46,7 +46,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalVersionPath")
+    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalFilePath")
     rest.length should equal(2)
     rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:30,$originalFilePath")
     rest.last should equal(s"data/folder,folderName,Folder,,,,,,,,")
@@ -78,7 +78,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalVersionPath")
+    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalFilePath")
     rest.length should equal(1)
     rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:00,")
     source.close()

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -16,6 +16,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
   "fileMetadataCsv" should "produce a file with the correct rows" in {
     val bagAdditionalFiles = BagAdditionalFiles(getClass.getResource(".").getPath.toPath)
     val lastModified = LocalDateTime.parse("2021-02-03T10:33:30.414")
+    val originalFilePath = "/originalFilePath"
     val validatedFileMetadata = ValidatedFileMetadata(
       UUID.randomUUID(),
       "name",
@@ -28,7 +29,8 @@ class BagAdditionalFilesSpec extends ExportSpec {
       "language".some,
       "legalStatus".some,
       "rightsCopyright".some,
-      "clientSideChecksumValue".some
+      "clientSideChecksumValue".some,
+      originalFilePath.some
     )
     val validatedDirectoryMetadata = ValidatedFileMetadata(
       UUID.randomUUID(),
@@ -36,7 +38,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
       "Folder",
       None, None,
       "folder",
-      None, None, None, None, None, None,
+      None, None, None, None, None, None, None
     )
     val file = bagAdditionalFiles.createFileMetadataCsv(List(validatedFileMetadata, validatedDirectoryMetadata)).unsafeRunSync()
 
@@ -44,10 +46,10 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified")
+    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalVersionId")
     rest.length should equal(2)
-    rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:30")
-    rest.last should equal(s"data/folder,folderName,Folder,,,,,,,")
+    rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:30,$originalFilePath")
+    rest.last should equal(s"data/folder,folderName,Folder,,,,,,,,")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
   }
@@ -67,7 +69,8 @@ class BagAdditionalFilesSpec extends ExportSpec {
       "language".some,
       "legalStatus".some,
       "rightsCopyright".some,
-      "clientSideChecksumValue".some
+      "clientSideChecksumValue".some,
+      None
     )
     val file = bagAdditionalFiles.createFileMetadataCsv(List(metadata)).unsafeRunSync()
 
@@ -75,19 +78,19 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified")
+    header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalVersionId")
     rest.length should equal(1)
-    rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:00")
+    rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:00,")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
   }
-  
+
   "createFfidMetadataCsv" should "produce a file with the correct rows" in {
     val bagAdditionalFiles = BagAdditionalFiles(getClass.getResource(".").getPath.toPath)
     val metadata = ValidatedFFIDMetadata("path", "extension", "puid", "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion")
-    
+
     val file = bagAdditionalFiles.createFfidMetadataCsv(List(metadata)).unsafeRunSync()
-    
+
     val source = Source.fromFile(file)
     val csvLines = source.getLines().toList
     val header = csvLines.head

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ChecksumValidatorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ChecksumValidatorSpec.scala
@@ -61,7 +61,7 @@ class ChecksumValidatorSpec extends ExportSpec {
       "language".some,
       "legalStatus".some,
       "rightsCopyright".some,
-      checksumValue.some)
+      checksumValue.some, None)
   }
 
   private def createBag(checksums: List[String]): Bag = {

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
@@ -186,7 +186,7 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
                                fileId;
                                fileType;
                                fileName;
-                               originalFile;
+                               originalFilePath;
                                metadata{
                                  clientSideFileSize;
                                  clientSideLastModifiedDate;

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
@@ -186,6 +186,7 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
                                fileId;
                                fileType;
                                fileName;
+                               originalFile;
                                metadata{
                                  clientSideFileSize;
                                  clientSideLastModifiedDate;

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/GraphQlApiSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/GraphQlApiSpec.scala
@@ -91,8 +91,9 @@ class GraphQlApiSpec extends ExportSpec {
     val fileId = UUID.randomUUID()
     val lastModified = LocalDateTime.now().some
     val fileMetadata = Metadata(1L.some, lastModified, "clientSideOriginalFilePath".some, "foiExemptionCode".some, "heldBy".some, "language".some, "legalStatus".some, "rightsCopyright".some, "clientSideChecksum".some)
+    val originalFilePath = "/originalFilePath".some
     val consignment = GetConsignmentExport.getConsignmentForExport.GetConsignment(
-      userId, Some(fixedDate), Some(fixedDate), Some(fixedDate), consignmentRef, Some(consignmentType), Some(series), Some(transferringBody), List(Files(fileId, "File".some, "name".some, fileMetadata, Option.empty, Option.empty))
+      userId, Some(fixedDate), Some(fixedDate), Some(fixedDate), consignmentRef, Some(consignmentType), Some(series), Some(transferringBody), List(Files(fileId, "File".some, "name".some, originalFilePath, fileMetadata, Option.empty, Option.empty))
     )
 
     doAnswer(() => Future(new BearerAccessToken("token"))).when(keycloak).serviceAccountToken[Identity](any[String], any[String])(
@@ -108,6 +109,7 @@ class GraphQlApiSpec extends ExportSpec {
     response.get.series should be(Some(series))
     response.get.transferringBody should be(Some(transferringBody))
     response.get.consignmentReference should be(consignmentRef)
+    response.get.files.head.originalFilePath should be(originalFilePath)
   }
 
   "the getConsignmentMetadata method" should "throw an exception if no data is returned" in {

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/S3FilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/S3FilesSpec.scala
@@ -45,7 +45,8 @@ class S3FilesSpec extends ExportSpec {
       "language".some,
       "legalStatus".some,
       "rightsCopyright".some,
-      "clientSideChecksumValue".some
+      "clientSideChecksumValue".some,
+      None
     )
 
     val validatedMetadata = List(metadata)
@@ -79,7 +80,8 @@ class S3FilesSpec extends ExportSpec {
       "language".some,
       "legalStatus".some,
       "rightsCopyright".some,
-      "clientSideChecksumValue".some
+      "clientSideChecksumValue".some,
+      None
     )
     val validatedMetadata = List(metadata)
 
@@ -103,11 +105,11 @@ class S3FilesSpec extends ExportSpec {
     val fileId2 = UUID.randomUUID()
     val metadata1 = ValidatedFileMetadata(
       fileId1, "name1", "File", 1L.some, LocalDateTime.now().some, "originalPath", "foiExemption".some, "heldBy".some,
-      "language".some, "legalStatus".some, "rightsCopyright".some, "clientSideChecksumValue".some
+      "language".some, "legalStatus".some, "rightsCopyright".some, "clientSideChecksumValue".some, None
     )
     val metadata2 = ValidatedFileMetadata(
       fileId2, "name2", "File", 1L.some, LocalDateTime.now().some, "originalPath", "foiExemption".some, "heldBy".some,
-      "language".some, "legalStatus".some, "rightsCopyright".some, "clientSideChecksumValue".some
+      "language".some, "legalStatus".some, "rightsCopyright".some, "clientSideChecksumValue".some, None
     )
 
     val validatedMetadata = List(metadata1, metadata2)

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ValidatorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ValidatorSpec.scala
@@ -15,6 +15,7 @@ class ValidatorSpec extends ExportSpec {
     UUID.randomUUID(),
     "File".some,
     "name".some,
+    None,
     Metadata(
       1L.some,
       LocalDateTime.now().some,
@@ -83,6 +84,7 @@ class ValidatorSpec extends ExportSpec {
       fileId,
       "File".some,
       "name".some,
+      None,
       Metadata(
         1L.some,
         Option.empty,
@@ -101,6 +103,7 @@ class ValidatorSpec extends ExportSpec {
       fileIdTwo,
       "File".some,
       "name".some,
+      None,
       Metadata(
         1L.some,
         LocalDateTime.parse("2021-02-03T10:33:30.414").some,
@@ -127,6 +130,7 @@ class ValidatorSpec extends ExportSpec {
       UUID.randomUUID(),
       "File".some,
       "name".some,
+      None,
       Metadata(
         1L.some,
         LocalDateTime.parse("2021-02-03T10:33:30.414").some,
@@ -145,6 +149,7 @@ class ValidatorSpec extends ExportSpec {
       fileId,
       "File".some,
       "name".some,
+      None,
       Metadata(
         1L.some,
         LocalDateTime.parse("2021-02-03T10:33:30.414").some,
@@ -166,7 +171,7 @@ class ValidatorSpec extends ExportSpec {
   "extractFFIDMetadata" should "return an error if the ffid metadata is missing" in {
     val validator = Validator(UUID.randomUUID())
     val fileId = UUID.randomUUID()
-    val files = List(Files(fileId,"File".some,"name".some, Metadata(None, None, None, None, None, None, None, None, None), Option.empty, Option.empty))
+    val files = List(Files(fileId,"File".some,"name".some, None, Metadata(None, None, None, None, None, None, None, None, None), Option.empty, Option.empty))
     val result = validator.extractFFIDMetadata(files)
     result.left.value.getMessage should equal(s"FFID metadata is missing for file id $fileId")
   }
@@ -176,7 +181,7 @@ class ValidatorSpec extends ExportSpec {
     val fileIdOne = UUID.randomUUID()
     val fileIdTwo = UUID.randomUUID()
     val metadata = Metadata(None, None, None, None, None, None, None, None, None)
-    val files = List(Files(fileIdOne,"File".some,"name".some, metadata, Option.empty, Option.empty), Files(fileIdTwo,"File".some,"name2".some, metadata, FfidMetadata("", "", "", "", "", List()).some, Option.empty))
+    val files = List(Files(fileIdOne,"File".some,"name".some, None, metadata, Option.empty, Option.empty), Files(fileIdTwo,"File".some,"name2".some, None, metadata, FfidMetadata("", "", "", "", "", List()).some, Option.empty))
     val result = validator.extractFFIDMetadata(files)
     result.left.value.getMessage should equal(s"FFID metadata is missing for file id $fileIdOne")
   }
@@ -186,7 +191,7 @@ class ValidatorSpec extends ExportSpec {
     val fileId = UUID.randomUUID()
     val metadata = Metadata(None, None, "filePath".some, None, None, None, None, None, None)
     val ffidMetadata = FfidMetadata("software", "softwareVersion", "binaryVersion", "containerVersion", "method", List(Matches("ext".some, "id", "puid".some)))
-    val files = List(Files(fileId,"File".some,"name".some, metadata, ffidMetadata.some, Option.empty))
+    val files = List(Files(fileId,"File".some,"name".some, None, metadata, ffidMetadata.some, Option.empty))
     val result = validator.extractFFIDMetadata(files)
     val expectedResult = ValidatedFFIDMetadata("filePath", "ext", "puid", "software", "softwareVersion", "binaryVersion", "containerVersion")
     result.right.value.head should equal(expectedResult)
@@ -197,7 +202,7 @@ class ValidatorSpec extends ExportSpec {
     val fileId = UUID.randomUUID()
     val metadata = Metadata(None, None, "filePath".some, None, None, None, None, None, None)
     val antivirusMetadata = AntivirusMetadata("software", "softwareVersion")
-    val files = List(Files(fileId,"File".some, "name".some, metadata, Option.empty, antivirusMetadata.some))
+    val files = List(Files(fileId,"File".some, "name".some, None, metadata, Option.empty, antivirusMetadata.some))
     val result = validator.extractAntivirusMetadata(files)
     val expectedResult = ValidatedAntivirusMetadata("filePath", "software", "softwareVersion")
     result.right.value.head should equal(expectedResult)
@@ -207,7 +212,7 @@ class ValidatorSpec extends ExportSpec {
     val validator = Validator(UUID.randomUUID())
     val fileId = UUID.randomUUID()
     val metadata = Metadata(None, None, "filePath".some, None, None, None, None, None, None)
-    val files = List(Files(fileId,"File".some, "name".some, metadata, Option.empty, Option.empty))
+    val files = List(Files(fileId,"File".some, "name".some, None, metadata, Option.empty, Option.empty))
     val result = validator.extractAntivirusMetadata(files)
     result.left.value.getMessage should equal(s"Antivirus metadata is missing for file id $fileId")
   }


### PR DESCRIPTION
This gets the originalFilePath if present, or empty string if not and adds it to the file-metadata.csv
