### PR TITLE
Prefix the original file path with /data

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
@@ -29,7 +29,7 @@ class BagAdditionalFiles(rootDirectory: Path) {
       f.language.getOrElse(""),
       f.foiExemptionCode.getOrElse(""),
       f.clientSideLastModifiedDate.map(d => DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").format(d)).getOrElse(""),
-      f.originalFile.getOrElse("")
+      f.originalFile.map(dataPath).getOrElse("")
     )
     )
     writeToCsv("file-metadata.csv", header, fileMetadataRows)

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -48,7 +48,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val rest = csvLines.tail
     header should equal("Filepath,FileName,FileType,Filesize,RightsCopyright,LegalStatus,HeldBy,Language,FoiExemptionCode,LastModified,OriginalFilePath")
     rest.length should equal(2)
-    rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:30,$originalFilePath")
+    rest.head should equal(s"data/originalPath,name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:30,data/$originalFilePath")
     rest.last should equal(s"data/folder,folderName,Folder,,,,,,,,")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()


### PR DESCRIPTION
All the file paths in the bagit files are prefixed with data/ but the
original file path for redacted files isn't and it should be. This adds
it in.
