### PR TITLE
Refactor the export

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagMetadata.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagMetadata.scala
@@ -76,7 +76,9 @@ object BagMetadata {
   val InternalSenderIdentifierKey = "Internal-Sender-Identifier"
   val ConsignmentTypeKey = "Consignment-Type"
 
+  case class UserDetails(contactName: String, contactEmail: String)
+
   def apply(keycloakClient: KeycloakClient)(implicit logger: SelfAwareStructuredLogger[IO]): BagMetadata = new BagMetadata(keycloakClient)(logger)
 }
 
-case class UserDetails(contactName: String, contactEmail: String)
+


### PR DESCRIPTION
The main class is getting quite long and it's about to get longer now
we're driving the metadata csv from the custom metadata query so I've
moved the BagMetadata into a different method.

I've also changed the graphql API to take a config and consignmentId as
arguments to the class. This avoids each method having to declare them
in the arguments.

I've updated the tests to match.
