### PR TITLE
TDR-2682 Add multi-value properties to export metadata csv

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
@@ -26,14 +26,14 @@ class BagAdditionalFiles(rootDirectory: Path) {
     val filteredMetadata: List[CustomMetadata] = customMetadata.filter(_.allowExport).sortBy(_.exportOrdinal.getOrElse(Int.MaxValue))
     val header: List[String] = filteredMetadata.map(f => f.fullName.getOrElse(f.name))
     val fileMetadataRows: List[List[String]] = files.map(file => {
-      val groupedMetadata = file.fileMetadata.groupBy(_.name).view.mapValues(_.head).toMap
-      filteredMetadata.map(fm => groupedMetadata.get(fm.name).map(m => {
-        if(m.name == "ClientSideOriginalFilepath") {
-          dataPath(m.value)
-        } else if(filteredMetadata.find(_.name == m.name).exists(_.dataType == DataType.DateTime)) {
-          LocalDateTime.parse(m.value, parseFormatter).format(formatter)
+      val groupedMetadata = file.fileMetadata.groupBy(_.name).view.mapValues(_.map(_.value).mkString("|")).toMap
+      filteredMetadata.map(customMetadata => groupedMetadata.get(customMetadata.name).map(fileMetadataValue => {
+        if(customMetadata.name == "ClientSideOriginalFilepath") {
+          dataPath(fileMetadataValue)
+        } else if(filteredMetadata.find(_.name == customMetadata.name).exists(_.dataType == DataType.DateTime)) {
+          LocalDateTime.parse(fileMetadataValue, parseFormatter).format(formatter)
         } else {
-          m.value
+          fileMetadataValue
         }
       }).getOrElse(""))
     })

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -33,7 +33,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val rest = csvLines.tail
     header should equal("File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,FOI Exemption Code,Last Modified Date,Checksum")
     rest.length should equal(2)
-    rest.head should equal("data/originalFilePath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:30,clientSideChecksumValue")
+    rest.head should equal("data/originalFilePath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption|foiExemption2,2021-02-03T10:33:30,clientSideChecksumValue")
     rest.last should equal(s"data/folder,folderName,Folder,,,,,,,,")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
@@ -52,7 +52,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val rest = csvLines.tail
     header should equal("File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,FOI Exemption Code,Last Modified Date,Checksum")
     rest.length should equal(1)
-    rest.head should equal(s"data/originalPath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption,2021-02-03T10:33:00,clientSideChecksumValue")
+    rest.head should equal(s"data/originalPath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption|foiExemption2,2021-02-03T10:33:00,clientSideChecksumValue")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
   }

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExportSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExportSpec.scala
@@ -43,6 +43,7 @@ abstract class ExportSpec extends AnyFlatSpec with MockitoSugar with Matchers wi
       FileMetadata("ClientSideLastModifiedDate", lastModified.format(DateTimeFormatter.ISO_DATE_TIME)),
       FileMetadata("ClientSideOriginalFilepath", originalPath),
       FileMetadata("FoiExemptionCode", "foiExemption"),
+      FileMetadata("FoiExemptionCode", "foiExemption2"),
       FileMetadata("HeldBy", "heldBy"),
       FileMetadata("Language", "language"),
       FileMetadata("LegalStatus", "legalStatus"),


### PR DESCRIPTION
Multi-properties are added to a single column using a '|' delimiter 