### PR TITLE
Close the BagValidator class.

### DIFF
--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagitSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagitSpec.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.nio.charset.Charset
 import java.nio.file.{Path, Paths}
 import java.util
-import java.util.UUID
+import cats.effect.IO
 
 import gov.loc.repository.bagit.domain.{Bag, Manifest, Metadata, Version}
 import gov.loc.repository.bagit.hash.{StandardSupportedAlgorithms, SupportedAlgorithm}
@@ -16,14 +16,14 @@ import scala.jdk.CollectionConverters._
 class BagitSpec extends ExportSpec {
   "the createBag method" should "call the bagit methods with the correct values" in {
     val createMock = mock[(Path, util.Collection[SupportedAlgorithm], Boolean, Metadata) => Bag]
-    val verifyMock = mock[(Bag, Boolean) => Unit]
+    val verifyMock = mock[(Bag, Boolean) => IO[Unit]]
     val metadataMock = mock[Metadata]
 
     val createPath: ArgumentCaptor[Path] = ArgumentCaptor.forClass(classOf[Path])
     val createAlgorithms: ArgumentCaptor[util.Collection[SupportedAlgorithm]] = ArgumentCaptor.forClass(classOf[util.Collection[SupportedAlgorithm]])
     val createIncludeHidden: ArgumentCaptor[Boolean] = ArgumentCaptor.forClass(classOf[Boolean])
     val createMetadata: ArgumentCaptor[Metadata] = ArgumentCaptor.forClass(classOf[Metadata])
-    val verfiyBag: ArgumentCaptor[Bag] = ArgumentCaptor.forClass(classOf[Bag])
+    val verifyBag: ArgumentCaptor[Bag] = ArgumentCaptor.forClass(classOf[Bag])
     val verifyIncludeHidden: ArgumentCaptor[Boolean] = ArgumentCaptor.forClass(classOf[Boolean])
 
     val bag = new Bag(Version.LATEST_BAGIT_VERSION())
@@ -31,7 +31,7 @@ class BagitSpec extends ExportSpec {
     val consignmentReference = "Consignment-Reference"
 
     doAnswer(() => bag).when(createMock).apply(createPath.capture(), createAlgorithms.capture(), createIncludeHidden.capture(), createMetadata.capture())
-    doAnswer(() => ()).when(verifyMock).apply(verfiyBag.capture(), verifyIncludeHidden.capture())
+    doAnswer(() => IO()).when(verifyMock).apply(verifyBag.capture(), verifyIncludeHidden.capture())
 
     bagit.createBag(consignmentReference, "root", metadataMock).unsafeRunSync()
 
@@ -40,7 +40,7 @@ class BagitSpec extends ExportSpec {
     createIncludeHidden.getValue should equal(true)
     createMetadata.getValue should equal(metadataMock)
 
-    verfiyBag.getValue.getVersion should equal(Version.LATEST_BAGIT_VERSION())
+    verifyBag.getValue.getVersion should equal(Version.LATEST_BAGIT_VERSION())
     verifyIncludeHidden.getValue should equal(true)
   }
 
@@ -52,7 +52,7 @@ class BagitSpec extends ExportSpec {
     val charset: ArgumentCaptor[Charset] = ArgumentCaptor.forClass(classOf[Charset])
     val manifests: ArgumentCaptor[util.Set[Manifest]] = ArgumentCaptor.forClass(classOf[util.Set[Manifest]])
 
-    val bagit = new Bagit(mock[(Path, util.Collection[SupportedAlgorithm], Boolean, Metadata) => Bag], mock[(Bag, Boolean) => Unit], writeTagManifests)
+    val bagit = new Bagit(mock[(Path, util.Collection[SupportedAlgorithm], Boolean, Metadata) => Bag], mock[(Bag, Boolean) => IO[Unit]], writeTagManifests)
 
     val bag = new Bag()
     bag.setFileEncoding(Charset.defaultCharset())


### PR DESCRIPTION
The `BagValidator` class creates a new thread pool when it's
instantiated. There is a close method which you're supposed to call on
the class which terminates the thread pool but we're not doing that.

I've wrapped this up in a cats-effect `Resource` which is the standard
way of dealing with things that need closing and it's now exiting
immediately.
