### PR TITLE
Add 'data/' prefix to 'OriginalFilepath'

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
@@ -28,7 +28,7 @@ class BagAdditionalFiles(rootDirectory: Path) {
     val fileMetadataRows: List[List[String]] = files.map(file => {
       val groupedMetadata = file.fileMetadata.groupBy(_.name).view.mapValues(_.map(_.value).mkString("|")).toMap
       filteredMetadata.map(customMetadata => groupedMetadata.get(customMetadata.name).map(fileMetadataValue => {
-        if(customMetadata.name == "ClientSideOriginalFilepath") {
+        if(customMetadata.name == "ClientSideOriginalFilepath" || customMetadata.name == "OriginalFilepath") {
           dataPath(fileMetadataValue)
         } else if(filteredMetadata.find(_.name == customMetadata.name).exists(_.dataType == DataType.DateTime)) {
           LocalDateTime.parse(fileMetadataValue, parseFormatter).format(formatter)

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -31,10 +31,10 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,FOI Exemption Code,Last Modified Date,Checksum")
+    header should equal("File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,FOI Exemption Code,Last Modified Date,Checksum,OriginalFilepath")
     rest.length should equal(2)
-    rest.head should equal("data/originalFilePath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption|foiExemption2,2021-02-03T10:33:30,clientSideChecksumValue")
-    rest.last should equal(s"data/folder,folderName,Folder,,,,,,,,")
+    rest.head should equal("data/originalFilePath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption|foiExemption2,2021-02-03T10:33:30,clientSideChecksumValue,data/nonRedactedFilepath")
+    rest.last should equal(s"data/folder,folderName,Folder,,,,,,,,,")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
   }
@@ -50,9 +50,9 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,FOI Exemption Code,Last Modified Date,Checksum")
+    header should equal("File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,FOI Exemption Code,Last Modified Date,Checksum,OriginalFilepath")
     rest.length should equal(1)
-    rest.head should equal(s"data/originalPath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption|foiExemption2,2021-02-03T10:33:00,clientSideChecksumValue")
+    rest.head should equal(s"data/originalPath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption|foiExemption2,2021-02-03T10:33:00,clientSideChecksumValue,data/nonRedactedFilepath")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
   }

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExportSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExportSpec.scala
@@ -48,7 +48,8 @@ abstract class ExportSpec extends AnyFlatSpec with MockitoSugar with Matchers wi
       FileMetadata("Language", "language"),
       FileMetadata("LegalStatus", "legalStatus"),
       FileMetadata("RightsCopyright", "rightsCopyright"),
-      FileMetadata("SHA256ClientSideChecksum", checkSum)
+      FileMetadata("SHA256ClientSideChecksum", checkSum),
+      FileMetadata("OriginalFilepath", "nonRedactedFilepath")
     )
   }
 }
@@ -72,6 +73,7 @@ object ExportSpec {
     createCustomMetadata("Language", "Language", 8),
     createCustomMetadata("LegalStatus", "Legal Status", 6),
     createCustomMetadata("RightsCopyright", "Rights Copyright", 5),
-    createCustomMetadata("SHA256ClientSideChecksum", "Checksum", 11)
+    createCustomMetadata("SHA256ClientSideChecksum", "Checksum", 11),
+    createCustomMetadata("OriginalFilepath", "OriginalFilepath", 12)
   )
 }


### PR DESCRIPTION
So the 'OriginalFilepath' value matches the non redacted version's 'ClientSideOriginalFilepath' value