### PR TITLE
TDR-3403 Add file extension "mismatch" and "format name" to Bagit export CSV

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,9 +9,9 @@ object Dependencies {
   private val awsUtilsVersion = "0.1.97"
 
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.156"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.341"
-  lazy val s3Utils =  "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
-  lazy val stepFunctionUtils =  "uk.gov.nationalarchives" %% "stepfunction-utils" % awsUtilsVersion
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.343"
+  lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
+  lazy val stepFunctionUtils = "uk.gov.nationalarchives" %% "stepfunction-utils" % awsUtilsVersion
   lazy val bagit = "gov.loc" % "bagit" % "5.2.0"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.1"
   lazy val decline = "com.monovore" %% "decline" % monovoreDeclineVersion
@@ -27,5 +27,5 @@ object Dependencies {
   lazy val mockitoScala = "org.mockito" %% "mockito-scala" % mockitoScalaVersion
   lazy val mockitoScalaTest = "org.mockito" %% "mockito-scala-scalatest" % mockitoScalaVersion
   lazy val keycloakCore = "org.keycloak" % "keycloak-core" % keycloakVersion
-  lazy val keycloakAdminClient =  "org.keycloak" % "keycloak-admin-client" % keycloakVersion
+  lazy val keycloakAdminClient = "org.keycloak" % "keycloak-admin-client" % keycloakVersion
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   private val awsUtilsVersion = "0.1.100"
 
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.161"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.343"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.344"
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
   lazy val stepFunctionUtils = "uk.gov.nationalarchives" %% "stepfunction-utils" % awsUtilsVersion
   lazy val bagit = "gov.loc" % "bagit" % "5.2.0"

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFiles.scala
@@ -28,9 +28,9 @@ class BagAdditionalFiles(rootDirectory: Path) {
     val fileMetadataRows: List[List[String]] = files.map(file => {
       val groupedMetadata = file.fileMetadata.groupBy(_.name).view.mapValues(_.map(_.value).mkString("|")).toMap
       filteredMetadata.map(customMetadata => groupedMetadata.get(customMetadata.name).map(fileMetadataValue => {
-        if(customMetadata.name == "ClientSideOriginalFilepath" || customMetadata.name == "OriginalFilepath") {
+        if (customMetadata.name == "ClientSideOriginalFilepath" || customMetadata.name == "OriginalFilepath") {
           dataPath(fileMetadataValue)
-        } else if(filteredMetadata.find(_.name == customMetadata.name).exists(_.dataType == DataType.DateTime)) {
+        } else if (filteredMetadata.find(_.name == customMetadata.name).exists(_.dataType == DataType.DateTime)) {
           LocalDateTime.parse(fileMetadataValue, parseFormatter).format(formatter)
         } else {
           fileMetadataValue
@@ -41,9 +41,9 @@ class BagAdditionalFiles(rootDirectory: Path) {
   }
 
   def createFfidMetadataCsv(ffidMetadataList: List[ValidatedFFIDMetadata]): IO[File] = {
-    val header = List("Filepath","Extension","PUID","FFID-Software","FFID-SoftwareVersion","FFID-BinarySignatureFileVersion","FFID-ContainerSignatureFileVersion")
+    val header = List("Filepath", "Extension", "PUID", "FormatName", "ExtensionMismatch", "FFID-Software", "FFID-SoftwareVersion", "FFID-BinarySignatureFileVersion", "FFID-ContainerSignatureFileVersion")
     val metadataRows = ffidMetadataList.map(f => {
-      List(dataPath(f.filePath), f.extension, f.puid, f.software, f.softwareVersion, f.binarySignatureFileVersion, f.containerSignatureFileVersion)
+      List(dataPath(f.filePath), f.extension, f.puid, f.formatName, f.extensionMismatch, f.software, f.softwareVersion, f.binarySignatureFileVersion, f.containerSignatureFileVersion)
     })
     writeToCsv("file-ffid.csv", header, metadataRows)
   }

--- a/src/main/scala/uk/gov/nationalarchives/consignmentexport/Validator.scala
+++ b/src/main/scala/uk/gov/nationalarchives/consignmentexport/Validator.scala
@@ -24,7 +24,7 @@ class Validator(consignmentId: UUID) {
       case Nil => Right(filesList.filter(!_.isFolder).flatMap(file => {
         val metadata = file.ffidMetadata.get
         metadata.matches.map(mm => {
-          ValidatedFFIDMetadata(file.getClientSideOriginalFilePath, mm.extension.getOrElse(""), mm.puid.getOrElse(""), metadata.software, metadata.softwareVersion, metadata.binarySignatureFileVersion, metadata.containerSignatureFileVersion)
+          ValidatedFFIDMetadata(file.getClientSideOriginalFilePath, mm.extension.getOrElse(""), mm.puid.getOrElse(""), mm.formatName.getOrElse(""), mm.fileExtensionMismatch.getOrElse(false), metadata.software, metadata.softwareVersion, metadata.binarySignatureFileVersion, metadata.containerSignatureFileVersion)
         })
       }))
       case _ => Left(new RuntimeException(fileErrors.mkString("\n")))
@@ -51,6 +51,8 @@ object Validator {
   case class ValidatedFFIDMetadata(filePath: String,
                                    extension: String,
                                    puid: String,
+                                   formatName: String,
+                                   extensionMismatch: Boolean,
                                    software: String,
                                    softwareVersion: String,
                                    binarySignatureFileVersion: String,

--- a/src/test/resources/json/get_consignment_for_export.json
+++ b/src/test/resources/json/get_consignment_for_export.json
@@ -67,7 +67,9 @@
               {
                 "extension": null,
                 "identificationBasis": "",
-                "puid": null
+                "puid": null,
+                "fileExtensionMismatch": false,
+                "formatName": ""
               }
             ],
             "containerSignatureFileVersion": "DROID_SignatureFile_V96.xml",

--- a/src/test/resources/json/get_consignment_for_export_different_checksum.json
+++ b/src/test/resources/json/get_consignment_for_export_different_checksum.json
@@ -66,7 +66,9 @@
               {
                 "extension": null,
                 "identificationBasis": "",
-                "puid": null
+                "puid": null,
+                "fileExtensionMismatch": false,
+                "formatName": ""
               }
             ],
             "containerSignatureFileVersion": "DROID_SignatureFile_V96.xml",

--- a/src/test/resources/json/get_consignment_for_export_empty_folders.json
+++ b/src/test/resources/json/get_consignment_for_export_empty_folders.json
@@ -66,7 +66,9 @@
               {
                 "extension": null,
                 "identificationBasis": "",
-                "puid": null
+                "puid": null,
+                "fileExtensionMismatch": false,
+                "formatName": ""
               }
             ],
             "containerSignatureFileVersion": "DROID_SignatureFile_V96.xml",

--- a/src/test/resources/json/get_consignment_missing_antivirus_metadata.json
+++ b/src/test/resources/json/get_consignment_missing_antivirus_metadata.json
@@ -66,7 +66,9 @@
               {
                 "extension": null,
                 "identificationBasis": "",
-                "puid": null
+                "puid": null,
+                "fileExtensionMismatch": false,
+                "formatName": ""
               }
             ],
             "containerSignatureFileVersion": "DROID_SignatureFile_V96.xml",

--- a/src/test/resources/json/get_judgment_consignment_for_export.json
+++ b/src/test/resources/json/get_judgment_consignment_for_export.json
@@ -66,7 +66,9 @@
               {
                 "extension": null,
                 "identificationBasis": "",
-                "puid": null
+                "puid": null,
+                "fileExtensionMismatch": false,
+                "formatName": ""
               }
             ],
             "containerSignatureFileVersion": "DROID_SignatureFile_V96.xml",

--- a/src/test/resources/json/get_judgment_consignment_for_export_different_checksum.json
+++ b/src/test/resources/json/get_judgment_consignment_for_export_different_checksum.json
@@ -66,7 +66,9 @@
               {
                 "extension": null,
                 "identificationBasis": "",
-                "puid": null
+                "puid": null,
+                "fileExtensionMismatch": false,
+                "formatName": ""
               }
             ],
             "containerSignatureFileVersion": "DROID_SignatureFile_V96.xml",

--- a/src/test/resources/json/get_judgment_consignment_missing_antivirus_metadata.json
+++ b/src/test/resources/json/get_judgment_consignment_missing_antivirus_metadata.json
@@ -66,7 +66,9 @@
               {
                 "extension": null,
                 "identificationBasis": "",
-                "puid": null
+                "puid": null,
+                "fileExtensionMismatch": false,
+                "formatName": ""
               }
             ],
             "containerSignatureFileVersion": "DROID_SignatureFile_V96.xml",

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -74,7 +74,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
 
   "createFfidMetadataCsv" should "produce a file with the correct rows" in {
     val bagAdditionalFiles = BagAdditionalFiles(getClass.getResource(".").getPath.toPath)
-    val metadata = ValidatedFFIDMetadata("path", "extension", "puid", "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion")
+    val metadata = ValidatedFFIDMetadata("path", "extension", "puid", "formatName", false, "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion")
 
     val file = bagAdditionalFiles.createFfidMetadataCsv(List(metadata)).unsafeRunSync()
 
@@ -82,9 +82,9 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("Filepath,Extension,PUID,FFID-Software,FFID-SoftwareVersion,FFID-BinarySignatureFileVersion,FFID-ContainerSignatureFileVersion")
+    header should equal("Filepath,Extension,PUID,FormatName,ExtensionMismatch,FFID-Software,FFID-SoftwareVersion,FFID-BinarySignatureFileVersion,FFID-ContainerSignatureFileVersion")
     rest.length should equal(1)
-    rest.head should equal("data/path,extension,puid,software,softwareVersion,binarySignatureFileVersion,containerSignatureFileVersion")
+    rest.head should equal("data/path,extension,puid,formatName,false,software,softwareVersion,binarySignatureFileVersion,containerSignatureFileVersion")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
   }

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -74,7 +74,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
 
   "createFfidMetadataCsv" should "produce a file with the correct rows" in {
     val bagAdditionalFiles = BagAdditionalFiles(getClass.getResource(".").getPath.toPath)
-    val metadata = ValidatedFFIDMetadata("path", "extension", "puid", "formatName", false, "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion")
+    val metadata = ValidatedFFIDMetadata("path", "extension", "puid", "formatName", "false", "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion")
 
     val file = bagAdditionalFiles.createFfidMetadataCsv(List(metadata)).unsafeRunSync()
 

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
@@ -84,9 +84,9 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
   def graphQlUrl: String = wiremockGraphqlServer.url(graphQlPath)
 
   def graphqlGetCustomMetadata(): StubMapping = wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
-      .withRequestBody(containing("customMetadata"))
-      .willReturn(okJson(fromResource(s"json/custom_metadata.json").mkString))
-    )
+    .withRequestBody(containing("customMetadata"))
+    .willReturn(okJson(fromResource(s"json/custom_metadata.json").mkString))
+  )
 
   def graphqlGetConsignmentMissingMetadata: StubMapping = wiremockGraphqlServer.stubFor(post(urlEqualTo(graphQlPath))
     .withRequestBody(equalToJson(generateGetConsignmentForExportQuery("50df01e6-2e5e-4269-97e7-531a755b417d")))
@@ -144,7 +144,7 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
   def stepFunctionPublish: StubMapping = wiremockSfnServer.stubFor(post(urlEqualTo(stepFunctionPublishPath))
     .willReturn(ok("Ok response body")))
 
-//  val s3Api: S3Mock = S3Mock(port = 8003, dir = "/tmp/s3")
+  //  val s3Api: S3Mock = S3Mock(port = 8003, dir = "/tmp/s3")
 
   override def beforeAll(): Unit = {
     wiremockS3Server.start()
@@ -213,7 +213,9 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
                                matches{
                                  extension;
                                  identificationBasis;
-                                 puid
+                                 puid;
+                                 fileExtensionMismatch;
+                                 formatName
                                }
                              };
                              antivirusMetadata{

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
@@ -144,7 +144,7 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
   def stepFunctionPublish: StubMapping = wiremockSfnServer.stubFor(post(urlEqualTo(stepFunctionPublishPath))
     .willReturn(ok("Ok response body")))
 
-  //  val s3Api: S3Mock = S3Mock(port = 8003, dir = "/tmp/s3")
+  // val s3Api: S3Mock = S3Mock(port = 8003, dir = "/tmp/s3")
 
   override def beforeAll(): Unit = {
     wiremockS3Server.start()

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ValidatorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ValidatorSpec.scala
@@ -66,10 +66,10 @@ class ValidatorSpec extends ExportSpec {
     val validator = Validator(UUID.randomUUID())
     val fileId = UUID.randomUUID()
     val metadata = FileMetadata("ClientSideOriginalFilepath", "filePath") :: Nil
-    val ffidMetadata = FfidMetadata("software", "softwareVersion", "binaryVersion", "containerVersion", "method", List(Matches("ext".some, "id", "puid".some)))
-    val files = List(Files(fileId,"File".some,"name".some, None, metadata, ffidMetadata.some, Option.empty))
+    val ffidMetadata = FfidMetadata("software", "softwareVersion", "binaryVersion", "containerVersion", "method", List(Matches("ext".some, "id", "puid".some, false.some, "formatName".some)))
+    val files = List(Files(fileId, "File".some, "name".some, None, metadata, ffidMetadata.some, Option.empty))
     val result = validator.extractFFIDMetadata(files)
-    val expectedResult = ValidatedFFIDMetadata("filePath", "ext", "puid", "software", "softwareVersion", "binaryVersion", "containerVersion")
+    val expectedResult = ValidatedFFIDMetadata("filePath", "ext", "puid", "formatName", extensionMismatch = false, "software", "softwareVersion", "binaryVersion", "containerVersion")
     result.right.value.head should equal(expectedResult)
   }
 
@@ -95,7 +95,7 @@ class ValidatorSpec extends ExportSpec {
     val fileId = UUID.randomUUID()
     val metadata = FileMetadata("ClientSideOriginalFilepath", "filePath") :: Nil
     val antivirusMetadata = AntivirusMetadata("software", "softwareVersion")
-    val files = List(Files(fileId,"File".some, "name".some, None, metadata, Option.empty, antivirusMetadata.some))
+    val files = List(Files(fileId, "File".some, "name".some, None, metadata, Option.empty, antivirusMetadata.some))
     val result = validator.extractAntivirusMetadata(files)
     val expectedResult = ValidatedAntivirusMetadata("filePath", "software", "softwareVersion")
     result.right.value.head should equal(expectedResult)
@@ -105,7 +105,7 @@ class ValidatorSpec extends ExportSpec {
     val validator = Validator(UUID.randomUUID())
     val fileId = UUID.randomUUID()
     val metadata = FileMetadata("ClientSideOriginalFilepath", "filePath") :: Nil
-    val files = List(Files(fileId,"File".some, "name".some, None, metadata, Option.empty, Option.empty))
+    val files = List(Files(fileId, "File".some, "name".some, None, metadata, Option.empty, Option.empty))
     val result = validator.extractAntivirusMetadata(files)
     result.left.value.getMessage should equal(s"Antivirus metadata is missing for file id $fileId")
   }

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ValidatorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ValidatorSpec.scala
@@ -69,7 +69,7 @@ class ValidatorSpec extends ExportSpec {
     val ffidMetadata = FfidMetadata("software", "softwareVersion", "binaryVersion", "containerVersion", "method", List(Matches("ext".some, "id", "puid".some, false.some, "formatName".some)))
     val files = List(Files(fileId, "File".some, "name".some, None, metadata, ffidMetadata.some, Option.empty))
     val result = validator.extractFFIDMetadata(files)
-    val expectedResult = ValidatedFFIDMetadata("filePath", "ext", "puid", "formatName", extensionMismatch = false, "software", "softwareVersion", "binaryVersion", "containerVersion")
+    val expectedResult = ValidatedFFIDMetadata("filePath", "ext", "puid", "formatName", "false", "software", "softwareVersion", "binaryVersion", "containerVersion")
     result.right.value.head should equal(expectedResult)
   }
 


### PR DESCRIPTION
[TDR-3403](https://national-archives.atlassian.net/browse/TDR-3403?atlOrigin=eyJpIjoiMjNkYzY1MTYxY2MxNDYxNjg2MjlhMTEwOTFkN2E4YjAiLCJwIjoiaiJ9)

- [x] Update Method to produce CSV in new format / order as per ticket request
- [x] Updated tests

[TDR-3403]: https://national-archives.atlassian.net/browse/TDR-3403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ