### PR TITLE
update tdr-generated-graphql version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   private val awsUtilsVersion = "0.1.107"
 
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.172"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.350"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.351"
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
   lazy val stepFunctionUtils = "uk.gov.nationalarchives" %% "stepfunction-utils" % awsUtilsVersion
   lazy val bagit = "gov.loc" % "bagit" % "5.2.0"

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -50,8 +50,6 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    println(header)
-    println(rest.head)
     header should equal("file_reference,File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,Last Modified Date,FOI Exemption Code,Checksum,OriginalFilepath,parent_reference")
     rest.length should equal(1)
     rest.head should equal(s",data/originalPath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,2021-02-03T10:33:00,foiExemption|foiExemption2,clientSideChecksumValue,data/nonRedactedFilepath,")

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/BagAdditionalFilesSpec.scala
@@ -18,23 +18,23 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val originalFilePath = "originalFilePath"
     val fileMetadata = createMetadata(lastModified, originalFilePath)
 
-    val validatedFileMetadata = createFile(originalFilePath, fileMetadata, "File", "name")
+    val validatedFileMetadata = createFile(originalFilePath, fileMetadata, "File", "name", "ref1", Some("ref2"))
     val folderMetadata: List[FileMetadata] = List(
       FileMetadata("Filename", "folderName"),
       FileMetadata("ClientSideOriginalFilepath", "folder"),
       FileMetadata("FileType", "Folder")
     )
-    val validatedDirectoryMetadata = createFile(originalFilePath, folderMetadata, "Folder", "folderName")
+    val validatedDirectoryMetadata = createFile(originalFilePath, folderMetadata, "Folder", "folderName", "ref1")
     val file = bagAdditionalFiles.createFileMetadataCsv(List(validatedFileMetadata, validatedDirectoryMetadata), customMetadata).unsafeRunSync()
 
     val source = Source.fromFile(file)
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,FOI Exemption Code,Last Modified Date,Checksum,OriginalFilepath")
+    header should equal("file_reference,File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,Last Modified Date,FOI Exemption Code,Checksum,OriginalFilepath,parent_reference")
     rest.length should equal(2)
-    rest.head should equal("data/originalFilePath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption|foiExemption2,2021-02-03T10:33:30,clientSideChecksumValue,data/nonRedactedFilepath")
-    rest.last should equal(s"data/folder,folderName,Folder,,,,,,,,,")
+    rest.head should equal(",data/originalFilePath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,2021-02-03T10:33:30,foiExemption|foiExemption2,clientSideChecksumValue,data/nonRedactedFilepath,")
+    rest.last should equal(s",data/folder,folderName,Folder,,,,,,,,,,")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
   }
@@ -43,16 +43,18 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val bagAdditionalFiles = BagAdditionalFiles(getClass.getResource(".").getPath.toPath)
     val lastModified: LocalDateTime = LocalDateTime.parse("2021-02-03T10:33:00.0")
     val fileMetadata = createMetadata(lastModified)
-    val metadata = createFile("originalPath", fileMetadata, "File", "name")
+    val metadata = createFile("originalPath", fileMetadata, "File", "name", "ref1")
     val file = bagAdditionalFiles.createFileMetadataCsv(List(metadata), customMetadata).unsafeRunSync()
 
     val source = Source.fromFile(file)
     val csvLines = source.getLines().toList
     val header = csvLines.head
     val rest = csvLines.tail
-    header should equal("File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,FOI Exemption Code,Last Modified Date,Checksum,OriginalFilepath")
+    println(header)
+    println(rest.head)
+    header should equal("file_reference,File Path,File Name,File Type,File Size,Rights Copyright,Legal Status,Held By,Language,Last Modified Date,FOI Exemption Code,Checksum,OriginalFilepath,parent_reference")
     rest.length should equal(1)
-    rest.head should equal(s"data/originalPath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,foiExemption|foiExemption2,2021-02-03T10:33:00,clientSideChecksumValue,data/nonRedactedFilepath")
+    rest.head should equal(s",data/originalPath,File Name,File,1,rightsCopyright,legalStatus,heldBy,language,2021-02-03T10:33:00,foiExemption|foiExemption2,clientSideChecksumValue,data/nonRedactedFilepath,")
     source.close()
     new File("exporter/src/test/resources/file-metadata.csv").delete()
   }
@@ -62,7 +64,7 @@ class BagAdditionalFilesSpec extends ExportSpec {
     val allowedForExport = customMetadata.head
     val onlyExportFirst = allowedForExport :: customMetadata.tail.map(cm => cm.copy(allowExport = false))
     val fileMetadata = createMetadata(LocalDateTime.now())
-    val metadata = createFile("originalPath", fileMetadata, "File", "name")
+    val metadata = createFile("originalPath", fileMetadata, "File", "name", "ref1")
 
     val file = bagAdditionalFiles.createFileMetadataCsv(List(metadata), onlyExportFirst).unsafeRunSync()
 

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ChecksumValidatorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ChecksumValidatorSpec.scala
@@ -49,7 +49,7 @@ class ChecksumValidatorSpec extends ExportSpec {
 
  private def createFiles(fileId: UUID, checksumValue: String): Files = {
   val metadata = createMetadata(LocalDateTime.parse("2021-02-03T10:33:30.414"), checkSum = checksumValue)
-  Files(fileId, "File".some, "name".some, None, metadata, None, None)
+  Files(fileId, "File".some, "name".some, None, None, None, metadata, None, None)
   }
 
   private def createBag(checksums: List[String]): Bag = {

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExportSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExportSpec.scala
@@ -22,10 +22,12 @@ import java.util.UUID
 abstract class ExportSpec extends AnyFlatSpec with MockitoSugar with Matchers with EitherValues {
   implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
-  def createFile(originalFilePath: String, fileMetadata: List[FileMetadata], fileType: String, fileName: String): Files = Files(
+  def createFile(originalFilePath: String, fileMetadata: List[FileMetadata], fileType: String, fileName: String, fileRef: String, parentRef: Option[String] = None): Files = Files(
     UUID.randomUUID(),
     fileType.some,
     fileName.some,
+    fileRef.some,
+    parentRef,
     originalFilePath.some,
     fileMetadata,
     None,
@@ -63,17 +65,19 @@ object ExportSpec {
   )
 
   val customMetadata: List[CustomMetadata] = List(
-    createCustomMetadata("ClientSideFileSize", "File Size", 4),
+    createCustomMetadata("ClientSideFileSize", "File Size", 5),
     createCustomMetadata("ClientSideLastModifiedDate", "Last Modified Date", 10, DateTime),
-    createCustomMetadata("ClientSideOriginalFilepath", "File Path", 1),
-    createCustomMetadata("Filename", "File Name", 2),
-    createCustomMetadata("FileType", "File Type", 3),
-    createCustomMetadata("FoiExemptionCode", "FOI Exemption Code", 9),
-    createCustomMetadata("HeldBy", "Held By", 7),
-    createCustomMetadata("Language", "Language", 8),
-    createCustomMetadata("LegalStatus", "Legal Status", 6),
-    createCustomMetadata("RightsCopyright", "Rights Copyright", 5),
-    createCustomMetadata("SHA256ClientSideChecksum", "Checksum", 11),
-    createCustomMetadata("OriginalFilepath", "OriginalFilepath", 12)
+    createCustomMetadata("ClientSideOriginalFilepath", "File Path", 2),
+    createCustomMetadata("Filename", "File Name", 3),
+    createCustomMetadata("FileType", "File Type", 4),
+    createCustomMetadata("FoiExemptionCode", "FOI Exemption Code", 10),
+    createCustomMetadata("HeldBy", "Held By", 8),
+    createCustomMetadata("Language", "Language", 9),
+    createCustomMetadata("LegalStatus", "Legal Status", 7),
+    createCustomMetadata("RightsCopyright", "Rights Copyright", 6),
+    createCustomMetadata("SHA256ClientSideChecksum", "Checksum", 12),
+    createCustomMetadata("OriginalFilepath", "OriginalFilepath", 13),
+    createCustomMetadata("FileReference", "file_reference", 1),
+    createCustomMetadata("ParentReference", "parent_reference", 14),
   )
 }

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ExternalServiceSpec.scala
@@ -193,6 +193,8 @@ class ExternalServiceSpec extends AnyFlatSpec with BeforeAndAfterEach with Befor
                                fileId;
                                fileType;
                                fileName;
+                               fileReference;
+                               parentReference;
                                originalFilePath;
                                fileMetadata{
                                  name;

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/GraphQlApiSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/GraphQlApiSpec.scala
@@ -94,7 +94,7 @@ class GraphQlApiSpec extends ExportSpec {
     val fileMetadata = createMetadata(lastModified, "clientSideOriginalFilePath", "clientSideChecksum")
     val originalFilePath = "/originalFilePath".some
     val consignment = GetConsignmentExport.getConsignmentForExport.GetConsignment(
-      userId, Some(fixedDate), Some(fixedDate), Some(fixedDate), consignmentRef, Some(consignmentType), None, Some(series), Some(transferringBody), List(Files(fileId, "File".some, "name".some, originalFilePath, fileMetadata, Option.empty, Option.empty))
+      userId, Some(fixedDate), Some(fixedDate), Some(fixedDate), consignmentRef, Some(consignmentType), None, Some(series), Some(transferringBody), List(Files(fileId, "File".some, "name".some, None, None, originalFilePath, fileMetadata, Option.empty, Option.empty))
     )
 
     doAnswer(() => Future(new BearerAccessToken("token"))).when(keycloak).serviceAccountToken[Identity](any[String], any[String])(

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/S3FilesSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/S3FilesSpec.scala
@@ -38,6 +38,8 @@ class S3FilesSpec extends ExportSpec {
       "File".some,
       "name1".some,
       None,
+      None,
+      None,
       fileMetadata,
       None, None
     )
@@ -67,6 +69,8 @@ class S3FilesSpec extends ExportSpec {
       "File".some,
       "name".some,
       None,
+      None,
+      None,
       fileMetadata,
       None, None
     )
@@ -91,8 +95,8 @@ class S3FilesSpec extends ExportSpec {
     val fileId1 = UUID.randomUUID()
     val fileId2 = UUID.randomUUID()
     val fileMetadata = createMetadata(LocalDateTime.now())
-    val metadata1 = File(fileId1, "File".some, "name1".some, None, fileMetadata, None, None)
-    val metadata2 = File(fileId2, "File".some, "name2".some, None, fileMetadata, None, None)
+    val metadata1 = File(fileId1, "File".some, "name1".some, None, None, None, fileMetadata, None, None)
+    val metadata2 = File(fileId2, "File".some, "name2".some, None, None, None, fileMetadata, None, None)
 
     val validatedMetadata = List(metadata1, metadata2)
 

--- a/src/test/scala/uk/gov/nationalarchives/consignmentexport/ValidatorSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/consignmentexport/ValidatorSpec.scala
@@ -16,6 +16,8 @@ class ValidatorSpec extends ExportSpec {
     "File".some,
     "name".some,
     None,
+    None,
+    None,
     createMetadata(LocalDateTime.now()),
     Option.empty,
     Option.empty
@@ -67,7 +69,7 @@ class ValidatorSpec extends ExportSpec {
     val fileId = UUID.randomUUID()
     val metadata = FileMetadata("ClientSideOriginalFilepath", "filePath") :: Nil
     val ffidMetadata = FfidMetadata("software", "softwareVersion", "binaryVersion", "containerVersion", "method", List(Matches("ext".some, "id", "puid".some, false.some, "formatName".some)))
-    val files = List(Files(fileId, "File".some, "name".some, None, metadata, ffidMetadata.some, Option.empty))
+    val files = List(Files(fileId, "File".some, "name".some, None, None, None, metadata, ffidMetadata.some, Option.empty))
     val result = validator.extractFFIDMetadata(files)
     val expectedResult = ValidatedFFIDMetadata("filePath", "ext", "puid", "formatName", "false", "software", "softwareVersion", "binaryVersion", "containerVersion")
     result.right.value.head should equal(expectedResult)
@@ -76,7 +78,7 @@ class ValidatorSpec extends ExportSpec {
   "extractFFIDMetadata" should "return an error if the ffid metadata is missing" in {
     val validator = Validator(UUID.randomUUID())
     val fileId = UUID.randomUUID()
-    val files = List(Files(fileId, "File".some, "name".some, None, Nil, Option.empty, Option.empty))
+    val files = List(Files(fileId, "File".some, "name".some, None, None, None, Nil, Option.empty, Option.empty))
     val result = validator.extractFFIDMetadata(files)
     result.left.value.getMessage should equal(s"FFID metadata is missing for file id $fileId")
   }
@@ -85,7 +87,7 @@ class ValidatorSpec extends ExportSpec {
     val validator = Validator(UUID.randomUUID())
     val fileIdOne = UUID.randomUUID()
     val fileIdTwo = UUID.randomUUID()
-    val files = List(Files(fileIdOne, "File".some, "name".some, None, Nil, Option.empty, Option.empty), Files(fileIdTwo, "File".some, "name2".some, None, Nil, FfidMetadata("", "", "", "", "", List()).some, Option.empty))
+    val files = List(Files(fileIdOne, "File".some, "name".some, None, None, None, Nil, Option.empty, Option.empty), Files(fileIdTwo, "File".some, "name2".some, None, None, None, Nil, FfidMetadata("", "", "", "", "", List()).some, Option.empty))
     val result = validator.extractFFIDMetadata(files)
     result.left.value.getMessage should equal(s"FFID metadata is missing for file id $fileIdOne")
   }
@@ -95,7 +97,7 @@ class ValidatorSpec extends ExportSpec {
     val fileId = UUID.randomUUID()
     val metadata = FileMetadata("ClientSideOriginalFilepath", "filePath") :: Nil
     val antivirusMetadata = AntivirusMetadata("software", "softwareVersion")
-    val files = List(Files(fileId, "File".some, "name".some, None, metadata, Option.empty, antivirusMetadata.some))
+    val files = List(Files(fileId, "File".some, "name".some, None, None, None, metadata, Option.empty, antivirusMetadata.some))
     val result = validator.extractAntivirusMetadata(files)
     val expectedResult = ValidatedAntivirusMetadata("filePath", "software", "softwareVersion")
     result.right.value.head should equal(expectedResult)
@@ -105,7 +107,7 @@ class ValidatorSpec extends ExportSpec {
     val validator = Validator(UUID.randomUUID())
     val fileId = UUID.randomUUID()
     val metadata = FileMetadata("ClientSideOriginalFilepath", "filePath") :: Nil
-    val files = List(Files(fileId, "File".some, "name".some, None, metadata, Option.empty, Option.empty))
+    val files = List(Files(fileId, "File".some, "name".some, None, None, None, metadata, Option.empty, Option.empty))
     val result = validator.extractAntivirusMetadata(files)
     result.left.value.getMessage should equal(s"Antivirus metadata is missing for file id $fileId")
   }


### PR DESCRIPTION
I've updated the tdr-generated-graphql to the latest version which includes the FileReference & ParentReference. The tests still needs to be written properly but I want to test if the values show up in the bagit file by testing it on intg.