### PR TITLE
Pin apline linux version to '3.19.1'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.19.1
 RUN apk add --no-cache bash tar curl wget && \
     apk update && \
     apk upgrade p11-kit busybox libretls zlib openssl libcrypto3 libssl3 giflib && \


### PR DESCRIPTION
Version '3.19.1' is currently tagged as 'latest'

'3.19.1' contains version '5.4.5-r0' of xz (https://pkgs.alpinelinux.org/packages?name=xz&branch=v3.19&repo=main&arch=x86_64&maintainer=) which is currently identified as not being affected by CVE-2024-3094: https://nvd.nist.gov/vuln/detail/CVE-2024-3094

Pin to this version as a precaution