### PR TITLE
Add TransferInitiatedDatetime to export metadata.

### DIFF
--- a/export/src/main/scala/uk/gov/nationalarchives/export/MetadataUtils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/MetadataUtils.scala
@@ -80,7 +80,7 @@ class MetadataUtils(config: Config) {
           .unique
           .transact(transactor)
       transferCompleteDate <-
-        sql""" SELECT TO_CHAR("TransferInitiatedDatetime",'YYYY-MM-DD HH:MI:SS') FROM "Consignment"
+        sql""" SELECT TO_CHAR("TransferInitiatedDatetime",'YYYY-MM-DD HH24:MI:SS') FROM "Consignment"
             WHERE "ConsignmentId" = CAST(${consignmentId.toString} AS UUID)
            """
           .query[Option[String]] //This shouldn't ever be empty but if it is it will crash the export so better safe than sorry

--- a/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
@@ -43,7 +43,7 @@ class MainTest extends TestUtils {
       val (consignmentId, fileIds, consignmentReference) = stubExternalServices(mappedPort)
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-      val expectedJson = s"""{"FFID":[],"PropertyName":"Value","TransferringBody":"Test","ConsignmentReference":"$consignmentReference","Series":"Test"}"""
+      val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 12:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}"""
       val serveEvents = s3Server.getAllServeEvents.asScala
       val metadataFileWriteBody = serveEvents
         .find(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
@@ -60,7 +60,7 @@ class MainTest extends TestUtils {
 
     val expectedJson =
       s"""{"FFID":[{"extension":"Extension","identificationBasis":"IdentificationBasis","puid":"PUID","extensionMismatch":true,"formatName":"FormatName"}],
-         |"PropertyName":"Value","TransferringBody":"Test","ConsignmentReference":"$consignmentReference","Series":"Test"}""".stripMargin.replaceAll("\n", "")
+         |"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 12:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}""".stripMargin.replaceAll("\n", "")
     val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
     metadataFileWriteBody should equal(expectedJson)
   }
@@ -73,7 +73,7 @@ class MainTest extends TestUtils {
 
     val expectedJson =
       s"""{"FFID":[{"extension":null,"identificationBasis":"IdentificationBasis","puid":null,"extensionMismatch":true,"formatName":null}],
-         |"PropertyName":"Value","TransferringBody":"Test","ConsignmentReference":"$consignmentReference","Series":"Test"}""".stripMargin.replaceAll("\n", "")
+         |"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 12:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}""".stripMargin.replaceAll("\n", "")
     val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
     metadataFileWriteBody should equal(expectedJson)
   }
@@ -83,7 +83,7 @@ class MainTest extends TestUtils {
     val (consignmentId, fileIds, consignmentReference) = stubExternalServices(mappedPort)
     addConsignmentMetadata(consignmentId, mappedPort)
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
-    val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","ConsignmentMetadataTest":"TestValue","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}"""
+    val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","ConsignmentReference":"$consignmentReference","TransferringBody":"Test","ConsignmentMetadataTest":"TestValue","TransferInitiatedDatetime":"2024-08-29 12:00:00"}"""
     val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
     metadataFileWriteBody should equal(expectedJson)
   }
@@ -99,7 +99,7 @@ class MainTest extends TestUtils {
     addFileMetadata(redactedMetadata, mappedPort, false)
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","OriginalFilepath":"/a/test/path","ConsignmentReference":"$consignmentReference","TransferringBody":"Test","OriginalFileReference":"Z12345"}"""
+    val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 12:00:00","OriginalFilepath":"/a/test/path","ConsignmentReference":"$consignmentReference","TransferringBody":"Test","OriginalFileReference":"Z12345"}"""
     val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
     metadataFileWriteBody should equal(expectedJson)
   }

--- a/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
@@ -43,7 +43,7 @@ class MainTest extends TestUtils {
       val (consignmentId, fileIds, consignmentReference) = stubExternalServices(mappedPort)
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-      val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 12:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}"""
+      val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 00:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}"""
       val serveEvents = s3Server.getAllServeEvents.asScala
       val metadataFileWriteBody = serveEvents
         .find(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
@@ -60,7 +60,7 @@ class MainTest extends TestUtils {
 
     val expectedJson =
       s"""{"FFID":[{"extension":"Extension","identificationBasis":"IdentificationBasis","puid":"PUID","extensionMismatch":true,"formatName":"FormatName"}],
-         |"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 12:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}""".stripMargin.replaceAll("\n", "")
+         |"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 00:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}""".stripMargin.replaceAll("\n", "")
     val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
     metadataFileWriteBody should equal(expectedJson)
   }
@@ -73,7 +73,7 @@ class MainTest extends TestUtils {
 
     val expectedJson =
       s"""{"FFID":[{"extension":null,"identificationBasis":"IdentificationBasis","puid":null,"extensionMismatch":true,"formatName":null}],
-         |"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 12:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}""".stripMargin.replaceAll("\n", "")
+         |"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 00:00:00","ConsignmentReference":"$consignmentReference","TransferringBody":"Test"}""".stripMargin.replaceAll("\n", "")
     val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
     metadataFileWriteBody should equal(expectedJson)
   }
@@ -83,7 +83,7 @@ class MainTest extends TestUtils {
     val (consignmentId, fileIds, consignmentReference) = stubExternalServices(mappedPort)
     addConsignmentMetadata(consignmentId, mappedPort)
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
-    val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","ConsignmentReference":"$consignmentReference","TransferringBody":"Test","ConsignmentMetadataTest":"TestValue","TransferInitiatedDatetime":"2024-08-29 12:00:00"}"""
+    val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","ConsignmentReference":"$consignmentReference","TransferringBody":"Test","ConsignmentMetadataTest":"TestValue","TransferInitiatedDatetime":"2024-08-29 00:00:00"}"""
     val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
     metadataFileWriteBody should equal(expectedJson)
   }
@@ -99,7 +99,7 @@ class MainTest extends TestUtils {
     addFileMetadata(redactedMetadata, mappedPort, false)
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 12:00:00","OriginalFilepath":"/a/test/path","ConsignmentReference":"$consignmentReference","TransferringBody":"Test","OriginalFileReference":"Z12345"}"""
+    val expectedJson = s"""{"FFID":[],"PropertyName":"Value","Series":"Test","TransferInitiatedDatetime":"2024-08-29 00:00:00","OriginalFilepath":"/a/test/path","ConsignmentReference":"$consignmentReference","TransferringBody":"Test","OriginalFileReference":"Z12345"}"""
     val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
     metadataFileWriteBody should equal(expectedJson)
   }

--- a/export/src/test/scala/uk/gov/nationalarchives/export/TestUtils.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/TestUtils.scala
@@ -235,8 +235,8 @@ class TestUtils extends AnyFlatSpec with TestContainerForAll with BeforeAndAfter
       _ <- sql"""INSERT INTO "Series" ("SeriesId", "BodyId", "Name", "Code") VALUES (CAST($seriesId AS UUID), CAST($bodyId AS UUID), 'Test', 'TST') """.update.run.transact(
         transactor
       )
-      _ <- sql""" INSERT INTO "Consignment" ("ConsignmentId", "UserId", "Datetime", "ConsignmentSequence", "ConsignmentReference", "ConsignmentType", "BodyId", "SeriesId")
-         VALUES (CAST($consignmentId AS UUID), CAST($userId AS UUID), CAST($dateTime AS TIMESTAMP), $sequence, $consignmentRef, 'standard', CAST($bodyId AS UUID), CAST($seriesId AS UUID)) """.update.run
+      _ <- sql""" INSERT INTO "Consignment" ("ConsignmentId", "UserId", "Datetime", "ConsignmentSequence", "ConsignmentReference", "ConsignmentType", "BodyId", "SeriesId", "TransferInitiatedDatetime")
+         VALUES (CAST($consignmentId AS UUID), CAST($userId AS UUID), CAST($dateTime AS TIMESTAMP), $sequence, $consignmentRef, 'standard', CAST($bodyId AS UUID), CAST($seriesId AS UUID), '2024-08-29 00:00:00')""".update.run
         .transact(transactor)
       _ <- fileIds.map { fileId =>
         sql""" INSERT INTO "File" ("FileId", "ConsignmentId", "UserId", "Datetime")


### PR DESCRIPTION
We need this on the DR2 side. I've cast the date to a string because
we don't need the full level of accuracy and it avoids any timezone
issues.
