### PR TITLE
Add list objects pagination and SNS error checking.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val export = (project in file("export"))
       doobie,
       doobiePostgres,
       snsUtils,
+      catsEffectTest % Test,
       testContainers % Test,
       testContainersPostgres % Test,
       postgres % Test,

--- a/export/src/main/resources/application.conf
+++ b/export/src/main/resources/application.conf
@@ -13,6 +13,8 @@ sfn {
 sns {
   endpoint = "https://sns.eu-west-2.amazonaws.com"
   topicArn = ${?OUTPUT_TOPIC_ARN}
+  messageGroupSize = 500
+  messageGroupSize = ${?SNS_MESSAGE_GROUP_SIZE}
 }
 db {
   useIamAuth = false

--- a/export/src/main/scala/uk/gov/nationalarchives/export/Main.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/Main.scala
@@ -22,7 +22,7 @@ object Main extends CommandIOApp("tdr-export", "Exports tdr files with a flat st
   case class Db(useIamAuth: Boolean, host: String, user: String, password: String, port: Int)
   case class S3(endpoint: String, cleanBucket: String, outputBucket: String, outputBucketJudgment: String)
   case class SFN(endpoint: String)
-  case class SNS(endpoint: String, topicArn: String)
+  case class SNS(endpoint: String, topicArn: String, messageGroupSize: Int)
   case class Config(db: Db, sfn: SFN, s3: S3, sns: SNS)
   implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
   implicit def hint[A]: ProductHint[A] = ProductHint[A](ConfigFieldMapping(CamelCase, CamelCase))

--- a/export/src/main/scala/uk/gov/nationalarchives/export/PublishUtils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/PublishUtils.scala
@@ -23,16 +23,11 @@ class PublishUtils(snsUtils: SNSUtils, config: Config) {
       if (groupResponses.isEmpty) {
         IO.pure(fileOutputs)
       } else {
-        publishMessages(groupResponses)
+        Temporal[IO].sleep(1.seconds) >> publishMessages(groupResponses)
       }
     }
 
-    fileOutputs.grouped(500).toList.flatTraverse { eachGroup =>
-      for {
-        results <- processGroup(eachGroup)
-        _ <- Temporal[IO].sleep(1.seconds)
-      } yield results
-    }
+    fileOutputs.grouped(500).toList.flatTraverse(processGroup)
   }
 }
 object PublishUtils {

--- a/export/src/main/scala/uk/gov/nationalarchives/export/PublishUtils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/PublishUtils.scala
@@ -1,0 +1,40 @@
+package uk.gov.nationalarchives.`export`
+
+import cats.effect.{IO, Temporal}
+import io.circe.Printer
+import uk.gov.nationalarchives.`export`.Main.Config
+import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
+import uk.gov.nationalarchives.aws.utils.sns.SNSClients.sns
+import uk.gov.nationalarchives.aws.utils.sns.SNSUtils
+import io.circe.syntax._
+import io.circe.generic.auto._
+import cats.syntax.all._
+
+import scala.concurrent.duration._
+
+class PublishUtils(snsUtils: SNSUtils, config: Config) {
+
+  def publishMessages(fileOutputs: List[FileOutput]): IO[List[FileOutput]] = {
+    def processGroup(eachGroup: List[FileOutput]): IO[List[FileOutput]] = {
+      val groupResponses = eachGroup.flatMap { fileOutput =>
+        val publishResponse = snsUtils.publish(fileOutput.asJson.printWith(Printer.noSpaces), config.sns.topicArn)
+        if (publishResponse.sdkHttpResponse().isSuccessful) None else Option(fileOutput)
+      }
+      if (groupResponses.isEmpty) {
+        IO.pure(fileOutputs)
+      } else {
+        publishMessages(groupResponses)
+      }
+    }
+
+    fileOutputs.grouped(500).toList.flatTraverse { eachGroup =>
+      for {
+        results <- processGroup(eachGroup)
+        _ <- Temporal[IO].sleep(1.seconds)
+      } yield results
+    }
+  }
+}
+object PublishUtils {
+  def apply(config: Config): PublishUtils = new PublishUtils(SNSUtils(sns(config.sns.endpoint)), config)
+}

--- a/export/src/main/scala/uk/gov/nationalarchives/export/PublishUtils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/PublishUtils.scala
@@ -27,7 +27,7 @@ class PublishUtils(snsUtils: SNSUtils, config: Config) {
       }
     }
 
-    fileOutputs.grouped(500).toList.flatTraverse(processGroup)
+    fileOutputs.grouped(config.sns.messageGroupSize).toList.flatTraverse(processGroup)
   }
 }
 object PublishUtils {

--- a/export/src/test/resources/application.conf
+++ b/export/src/test/resources/application.conf
@@ -10,6 +10,7 @@ sfn {
 sns {
   endpoint = "http://localhost:9011"
   topicArn = "testTopic"
+  messageGroupSize = 1
 }
 db {
   useIamAuth = false

--- a/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
@@ -1,0 +1,31 @@
+package uk.gov.nationalarchives.`export`
+
+import cats.effect.testkit.TestControl
+import cats.effect.unsafe.implicits.global
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+import software.amazon.awssdk.http.SdkHttpFullResponse
+import software.amazon.awssdk.services.sns.model.PublishResponse
+import uk.gov.nationalarchives.`export`.Main.{Config, Db, S3, SFN, SNS}
+import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
+import uk.gov.nationalarchives.aws.utils.sns.SNSUtils
+
+import java.util.UUID
+
+class PublishUtilsTest extends AnyFlatSpec with MockitoSugar {
+
+  "publishMessages" should "retry any failed messages" in {
+    val config: Config = Config(Db(false, "", "", "", 5432), SFN(""), S3("", "", "", ""), SNS("", "testTopic"))
+    val snsUtils = mock[SNSUtils]
+    def response(statusCode: Int): PublishResponse = PublishResponse.builder.sdkHttpResponse(SdkHttpFullResponse.builder.statusCode(statusCode).build).build().asInstanceOf[PublishResponse]
+
+    when(snsUtils.publish(any[String], any[String]))
+      .thenReturn(response(400), List.fill(10)(response(400)) ++ List(response(200)):_*)
+    val outputs = (1 to 600).map(_ => FileOutput("", UUID.randomUUID, None, None)).toList
+
+    val fileOutputs = TestControl.executeEmbed(new PublishUtils(snsUtils, config).publishMessages(outputs))
+
+    fileOutputs.unsafeRunSync().size should equal(611)
+  }
+}

--- a/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
@@ -16,7 +16,7 @@ import java.util.UUID
 class PublishUtilsTest extends AnyFlatSpec with MockitoSugar {
 
   "publishMessages" should "retry any failed messages" in {
-    val config: Config = Config(Db(false, "", "", "", 5432), SFN(""), S3("", "", "", ""), SNS("", "testTopic"))
+    val config: Config = Config(Db(useIamAuth = false, "", "", "", 5432), SFN(""), S3("", "", "", ""), SNS("", "testTopic", 500))
     val snsUtils = mock[SNSUtils]
     def response(statusCode: Int): PublishResponse = PublishResponse.builder.sdkHttpResponse(SdkHttpFullResponse.builder.statusCode(statusCode).build).build().asInstanceOf[PublishResponse]
 

--- a/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
@@ -18,7 +18,7 @@ import scala.jdk.CollectionConverters.ListHasAsScala
 
 class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with TableDrivenPropertyChecks {
 
-  val config: Config = Config(Db(false, "", "", "", 5432), SFN(""), S3("", "testCleanBucket", "outputBucket", "outputBucketJudgment"), SNS("", "testTopic"))
+  val config: Config = Config(Db(useIamAuth = false, "", "", "", 5432), SFN(""), S3("", "testCleanBucket", "outputBucket", "outputBucketJudgment"), SNS("", "testTopic", 500))
 
   "copyFiles" should "copy the files returned by list objects" in {
     val client = mock[S3Client]
@@ -86,7 +86,6 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     lastCall.prefix() should equal(s"$consignmentId/")
     lastCall.continuationToken() should equal(null)
   }
-
 
   "copyFiles" should "not copy any files if there are none in the clean bucket" in {
     val client = mock[S3Client]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
   lazy val snsUtils = "uk.gov.nationalarchives" %% "sns-utils" % awsUtilsVersion
   lazy val bagit = "gov.loc" % "bagit" % "5.2.0"
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.4"
+  lazy val catsEffectTest = "org.typelevel" %% "cats-effect-testkit" % "3.5.4"
   lazy val decline = "com.monovore" %% "decline" % monovoreDeclineVersion
   lazy val declineEffect = "com.monovore" %% "decline-effect" % monovoreDeclineVersion
   lazy val doobie = "org.tpolecat" %% "doobie-core" % doobieVersion


### PR DESCRIPTION
I noticed that this was only sending 1000 messages to the SNS topic.

I originally thought that this was some kind of soft limit on the number
of messages so I've grouped them into batches of 500 and added a 1
second wait between them. It will also check for errors and try again if
there are any.

It turned out that this wasn't the problem after all.

The problem is that listObjectsV2 only returns a maximum of 1000 items.
I really should have noticed that. It now recursively fetches
everything.

Given that the error checking and grouping of the SNS send isn't a bad
idea, even though that wasn't actually the issue, I'm going to leave it
in.
