### PR TITLE
Tdrd nojira strip object tagging

### DIFF
--- a/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
@@ -6,7 +6,7 @@ import io.circe.syntax._
 import io.circe.{Json, JsonObject, Printer}
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Object}
+import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Object, TaggingDirective}
 import uk.gov.nationalarchives.`export`.Main.Config
 import uk.gov.nationalarchives.`export`.MetadataUtils.{ConsignmentType, Judgment, Metadata, Standard}
 import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
@@ -52,6 +52,7 @@ class S3Utils(config: Config, s3Client: S3Client) {
           .sourceBucket(config.s3.cleanBucket)
           .destinationKey(destinationKey)
           .destinationBucket(destinationBucket)
+          .taggingDirective(TaggingDirective.REPLACE)
           .build()
         s3Client.copyObject(copyRequest)
         val series = consignmentMetadata.find(_.propertyName == "Series").map(_.value)

--- a/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
@@ -6,7 +6,7 @@ import io.circe.syntax._
 import io.circe.{Json, JsonObject, Printer}
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Object, TaggingDirective}
+import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Object, Tagging, TaggingDirective}
 import uk.gov.nationalarchives.`export`.Main.Config
 import uk.gov.nationalarchives.`export`.MetadataUtils.{ConsignmentType, Judgment, Metadata, Standard}
 import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
@@ -53,6 +53,7 @@ class S3Utils(config: Config, s3Client: S3Client) {
           .destinationKey(destinationKey)
           .destinationBucket(destinationBucket)
           .taggingDirective(TaggingDirective.REPLACE)
+          .tagging(Tagging.builder().build())
           .build()
         s3Client.copyObject(copyRequest)
         val series = consignmentMetadata.find(_.propertyName == "Series").map(_.value)


### PR DESCRIPTION
Having object tagging causes permission issues with downstream service when copy from TDR s3 buckets

TDR should be serving up s3 objects clean with any necessary information held in the metadata

Need to specify empty tag set when using 'x-amz-tagging-directive=REPLACE'

See documentation here: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_RequestParameters