### PR TITLE
Change new export file location

### DIFF
--- a/export/src/main/scala/uk/gov/nationalarchives/export/Main.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/Main.scala
@@ -43,7 +43,7 @@ object Main extends CommandIOApp("tdr-export", "Exports tdr files with a flat st
       fileMetadata <- metadataUtils.getFileMetadata(consignmentId)
       _ <- IO.raiseWhen(fileMetadata.isEmpty)(new RuntimeException(s"Metadata for consignment $consignmentId is missing"))
       ffidMetadata <- metadataUtils.getFFIDMetadata(consignmentId)
-      _ <- s3Utils.putMetadata(consignmentType, fileOutputs.map(_.fileId), fileMetadata, consignmentMetadata, ffidMetadata)
+      _ <- s3Utils.putMetadata(consignmentType, fileOutputs, fileMetadata, consignmentMetadata, ffidMetadata)
       _ <- publishUtils.publishMessages(fileOutputs)
       _ <- stepFunction.publishSuccess(taskToken)
       _ <- heartBeat.cancel

--- a/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
@@ -3,7 +3,7 @@ package uk.gov.nationalarchives.`export`
 import cats.effect.IO
 import io.circe.generic.auto._
 import io.circe.syntax._
-import io.circe.{Json, JsonObject, Printer}
+import io.circe.{Json, JsonObject}
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Object, Tagging, TaggingDirective}
@@ -45,12 +45,14 @@ class S3Utils(config: Config, s3Client: S3Client) {
     getAllObjects(s"$consignmentId/")
       .map { s3Object =>
         val key = s3Object.key
-        val destinationKey = key.split("/").last
+        val fileId = UUID.randomUUID()
+        val assetId = key.split("/").last
+        val destinationKey = s"$assetId/$fileId"
         val copyRequest = CopyObjectRequest
           .builder()
           .sourceKey(key)
           .sourceBucket(config.s3.cleanBucket)
-          .destinationKey(s"$destinationKey/${UUID.randomUUID()}")
+          .destinationKey(destinationKey)
           .destinationBucket(destinationBucket)
           .taggingDirective(TaggingDirective.REPLACE)
           .tagging(Tagging.builder().build())
@@ -58,16 +60,16 @@ class S3Utils(config: Config, s3Client: S3Client) {
         s3Client.copyObject(copyRequest)
         val series = consignmentMetadata.find(_.propertyName == "Series").map(_.value)
         val body = consignmentMetadata.find(_.propertyName == "TransferringBody").map(_.value)
-        FileOutput(destinationBucket, UUID.fromString(destinationKey), body, series)
+        FileOutput(destinationBucket, UUID.fromString(assetId), fileId, body, series)
       }
   }
 
   def putMetadata(
-      consignmentType: ConsignmentType,
-      fileIds: List[UUID],
-      fileMetadata: List[Metadata],
-      consignmentMetadata: List[Metadata],
-      ffidMetadata: Map[UUID, List[MetadataUtils.FFID]]
+     consignmentType: ConsignmentType,
+     fileOutputs: List[FileOutput],
+     fileMetadata: List[Metadata],
+     consignmentMetadata: List[Metadata],
+     ffidMetadata: Map[UUID, List[MetadataUtils.FFID]]
   ): IO[Unit] = IO.blocking {
     val groupedMetadata = fileMetadata.groupBy(_.id)
     val outputBucket = consignmentType match {
@@ -78,12 +80,12 @@ class S3Utils(config: Config, s3Client: S3Client) {
     def jsonFromMetadata(metadata: List[Metadata]): Map[String, Json] =
       metadata.map(m => m.propertyName -> Json.fromString(m.value)).toMap
 
-    fileIds.foreach { fileId =>
-      val ffidArray = ffidMetadata.getOrElse(fileId, Nil)
+    fileOutputs.foreach { fileOutput =>
+      val ffidArray = ffidMetadata.getOrElse(fileOutput.assetId, Nil)
       val metadataJson = groupedMetadata
-        .get(fileId)
+        .get(fileOutput.assetId)
         .map(jsonFromMetadata)
-        .getOrElse(Map.empty) ++ jsonFromMetadata(consignmentMetadata)
+        .getOrElse(Map.empty) ++ jsonFromMetadata(consignmentMetadata) ++ Map("fileId" -> Json.fromString(fileOutput.fileId.toString))
       val ffidObject = JsonObject.fromMap(Map("FFID" -> ffidArray.asJson))
       val allObjects = JsonObject
         .fromMap(metadataJson)
@@ -91,7 +93,7 @@ class S3Utils(config: Config, s3Client: S3Client) {
         .toJson
 
       val body = RequestBody.fromString(Json.arr(allObjects).noSpaces)
-      val request = PutObjectRequest.builder.bucket(outputBucket).key(s"$fileId.metadata").build
+      val request = PutObjectRequest.builder.bucket(outputBucket).key(s"${fileOutput.assetId}.metadata").build
       s3Client.putObject(request, body)
     }
   }
@@ -100,5 +102,5 @@ class S3Utils(config: Config, s3Client: S3Client) {
 object S3Utils {
   def apply(config: Config, s3Client: S3Client) = new S3Utils(config, s3Client)
 
-  case class FileOutput(bucket: String, fileId: UUID, transferringBody: Option[String], series: Option[String])
+  case class FileOutput(bucket: String, assetId: UUID, fileId: UUID, transferringBody: Option[String], series: Option[String])
 }

--- a/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
@@ -50,7 +50,7 @@ class S3Utils(config: Config, s3Client: S3Client) {
           .builder()
           .sourceKey(key)
           .sourceBucket(config.s3.cleanBucket)
-          .destinationKey(destinationKey)
+          .destinationKey(s"$destinationKey/${UUID.randomUUID()}")
           .destinationBucket(destinationBucket)
           .taggingDirective(TaggingDirective.REPLACE)
           .tagging(Tagging.builder().build())
@@ -89,8 +89,8 @@ class S3Utils(config: Config, s3Client: S3Client) {
         .fromMap(metadataJson)
         .deepMerge(ffidObject)
         .toJson
-        .printWith(Printer.noSpaces)
-      val body = RequestBody.fromString(allObjects)
+
+      val body = RequestBody.fromString(Json.arr(allObjects).noSpaces)
       val request = PutObjectRequest.builder.bucket(outputBucket).key(s"$fileId.metadata").build
       s3Client.putObject(request, body)
     }

--- a/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
@@ -36,7 +36,7 @@ class MainTest extends TestUtils {
     val snsMessage = snsServer.getAllServeEvents.asScala.head.getRequest.getFormParameters.get("Message").values().get(0)
     val fileOutput = decode[FileOutput](snsMessage).value
     fileOutput.bucket should equal("output")
-    fileOutput.fileId should equal(fileIds.head)
+    fileOutput.assetId should equal(fileIds.head)
   }
 
   "run" should "only write the body name, series name, metadata schema library version and consignment reference if there is no file or consignment metadata" in withContainers {
@@ -52,7 +52,7 @@ class MainTest extends TestUtils {
         .getOrElse("")
       val jsonReturned = metadataFileWriteBody.split("\n").tail.head.trim
 
-      JsonPath.read[Int](jsonReturned, "$.[0].size()")  shouldEqual 7
+      JsonPath.read[Int](jsonReturned, "$.[0].size()")  shouldEqual 8
       JsonPath.read[String](jsonReturned, "$.[0].PropertyName") shouldEqual "Value"
       JsonPath.read[String](jsonReturned, "$.[0].Series") shouldEqual "Test"
       JsonPath.read[String](jsonReturned, "$.[0].TransferInitiatedDatetime") shouldEqual "2024-08-29 00:00:00"

--- a/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
@@ -50,7 +50,7 @@ class MainTest extends TestUtils {
         .find(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
         .map(_.getRequest.getBodyAsString)
         .getOrElse("")
-      val jsonReturned = metadataFileWriteBody.split("\n").tail.head.trim
+      val jsonReturned = metadataFileWriteBody.split("\n").tail.head.trim.dropRight(1).drop(1)
 
       JsonPath.read[Int](jsonReturned, "$.size()")  shouldEqual 7
       JsonPath.read[String](jsonReturned, "$.PropertyName") shouldEqual "Value"
@@ -69,7 +69,7 @@ class MainTest extends TestUtils {
     fileIds.foreach(fileId => addFFIDMetadata(fileId, mappedPort))
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
+    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT).drop(1).dropRight(1)
 
     JsonPath.read[Int](metadataFileWriteBody, "$.FFID[0].size()")  shouldEqual 5
     JsonPath.read[String](metadataFileWriteBody, "$.FFID[0].extension") shouldEqual "Extension"
@@ -87,7 +87,7 @@ class MainTest extends TestUtils {
     fileIds.foreach(fileId => addFFIDMetadata(fileId, mappedPort, hasNullMatchValues = true))
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
+    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT).drop(1).dropRight(1)
 
     JsonPath.read[Int](metadataFileWriteBody, "$.FFID[0].size()")  shouldEqual 5
     JsonPath.read[Option[String]](metadataFileWriteBody,   "$.FFID[0].extension") shouldEqual null
@@ -105,7 +105,7 @@ class MainTest extends TestUtils {
     addConsignmentMetadata(consignmentId, mappedPort)
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
+    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT).drop(1).dropRight(1)
     JsonPath.read[java.util.List[Any]](metadataFileWriteBody, "$.FFID").asScala.toArray shouldEqual Array.empty[Any]
     JsonPath.read[String](metadataFileWriteBody, "$.PropertyName") shouldEqual "Value"
     JsonPath.read[String](metadataFileWriteBody, "$.Series") shouldEqual "Test"
@@ -128,7 +128,7 @@ class MainTest extends TestUtils {
     addFileMetadata(redactedMetadata, mappedPort, includeFFIDMetadata = false)
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
+    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT).drop(1).dropRight(1)
 
     JsonPath.read[java.util.List[Any]](metadataFileWriteBody, "$.FFID").asScala.toArray shouldEqual Array.empty[Any]
     JsonPath.read[String](metadataFileWriteBody, "$.OriginalFilepath") shouldEqual "/a/test/path"

--- a/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
@@ -50,15 +50,15 @@ class MainTest extends TestUtils {
         .find(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
         .map(_.getRequest.getBodyAsString)
         .getOrElse("")
-      val jsonReturned = metadataFileWriteBody.split("\n").tail.head.trim.dropRight(1).drop(1)
+      val jsonReturned = metadataFileWriteBody.split("\n").tail.head.trim
 
-      JsonPath.read[Int](jsonReturned, "$.size()")  shouldEqual 7
-      JsonPath.read[String](jsonReturned, "$.PropertyName") shouldEqual "Value"
-      JsonPath.read[String](jsonReturned, "$.Series") shouldEqual "Test"
-      JsonPath.read[String](jsonReturned, "$.TransferInitiatedDatetime") shouldEqual "2024-08-29 00:00:00"
-      JsonPath.read[String](jsonReturned, "$.ConsignmentReference") shouldEqual consignmentReference
-      JsonPath.read[String](jsonReturned, "$.TransferringBody") shouldEqual "Test"
-      JsonPath.read[String](jsonReturned, "$.MetadataSchemaLibraryVersion") shouldEqual "Schema-Library-Version-v0.1"
+      JsonPath.read[Int](jsonReturned, "$.[0].size()")  shouldEqual 7
+      JsonPath.read[String](jsonReturned, "$.[0].PropertyName") shouldEqual "Value"
+      JsonPath.read[String](jsonReturned, "$.[0].Series") shouldEqual "Test"
+      JsonPath.read[String](jsonReturned, "$.[0].TransferInitiatedDatetime") shouldEqual "2024-08-29 00:00:00"
+      JsonPath.read[String](jsonReturned, "$.[0].ConsignmentReference") shouldEqual consignmentReference
+      JsonPath.read[String](jsonReturned, "$.[0].TransferringBody") shouldEqual "Test"
+      JsonPath.read[String](jsonReturned, "$.[0].MetadataSchemaLibraryVersion") shouldEqual "Schema-Library-Version-v0.1"
 
   }
 
@@ -69,14 +69,14 @@ class MainTest extends TestUtils {
     fileIds.foreach(fileId => addFFIDMetadata(fileId, mappedPort))
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT).drop(1).dropRight(1)
+    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
 
-    JsonPath.read[Int](metadataFileWriteBody, "$.FFID[0].size()")  shouldEqual 5
-    JsonPath.read[String](metadataFileWriteBody, "$.FFID[0].extension") shouldEqual "Extension"
-    JsonPath.read[String](metadataFileWriteBody, "$.FFID[0].identificationBasis") shouldEqual "IdentificationBasis"
-    JsonPath.read[String](metadataFileWriteBody, "$.FFID[0].puid") shouldEqual "PUID"
-    JsonPath.read[Boolean](metadataFileWriteBody, "$.FFID[0].extensionMismatch") shouldEqual true
-    JsonPath.read[String](metadataFileWriteBody, "$.FFID[0].formatName") shouldEqual "FormatName"
+    JsonPath.read[Int](metadataFileWriteBody, "$.[0].FFID[0].size()")  shouldEqual 5
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].FFID[0].extension") shouldEqual "Extension"
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].FFID[0].identificationBasis") shouldEqual "IdentificationBasis"
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].FFID[0].puid") shouldEqual "PUID"
+    JsonPath.read[Boolean](metadataFileWriteBody, "$.[0].FFID[0].extensionMismatch") shouldEqual true
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].FFID[0].formatName") shouldEqual "FormatName"
 
   }
 
@@ -87,14 +87,14 @@ class MainTest extends TestUtils {
     fileIds.foreach(fileId => addFFIDMetadata(fileId, mappedPort, hasNullMatchValues = true))
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT).drop(1).dropRight(1)
+    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
 
-    JsonPath.read[Int](metadataFileWriteBody, "$.FFID[0].size()")  shouldEqual 5
-    JsonPath.read[Option[String]](metadataFileWriteBody,   "$.FFID[0].extension") shouldEqual null
-    JsonPath.read[String](metadataFileWriteBody, "$.FFID[0].identificationBasis") shouldEqual "IdentificationBasis"
-    JsonPath.read[Option[String]](metadataFileWriteBody,   "$.FFID[0].puid") shouldEqual null
-    JsonPath.read[Boolean](metadataFileWriteBody,"$.FFID[0].extensionMismatch") shouldEqual true
-    JsonPath.read[Option[String]](metadataFileWriteBody,   "$.FFID[0].formatName") shouldEqual null
+    JsonPath.read[Int](metadataFileWriteBody, "$.[0].FFID[0].size()")  shouldEqual 5
+    JsonPath.read[Option[String]](metadataFileWriteBody, "$.[0].FFID[0].extension") shouldEqual null
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].FFID[0].identificationBasis") shouldEqual "IdentificationBasis"
+    JsonPath.read[Option[String]](metadataFileWriteBody, "$.[0].FFID[0].puid") shouldEqual null
+    JsonPath.read[Boolean](metadataFileWriteBody,"$.[0].FFID[0].extensionMismatch") shouldEqual true
+    JsonPath.read[Option[String]](metadataFileWriteBody, "$.[0].FFID[0].formatName") shouldEqual null
 
   }
 
@@ -105,14 +105,14 @@ class MainTest extends TestUtils {
     addConsignmentMetadata(consignmentId, mappedPort)
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT).drop(1).dropRight(1)
-    JsonPath.read[java.util.List[Any]](metadataFileWriteBody, "$.FFID").asScala.toArray shouldEqual Array.empty[Any]
-    JsonPath.read[String](metadataFileWriteBody, "$.PropertyName") shouldEqual "Value"
-    JsonPath.read[String](metadataFileWriteBody, "$.Series") shouldEqual "Test"
-    JsonPath.read[String](metadataFileWriteBody, "$.TransferInitiatedDatetime") shouldEqual "2024-08-29 00:00:00"
-    JsonPath.read[String](metadataFileWriteBody, "$.ConsignmentReference") shouldEqual consignmentReference
-    JsonPath.read[String](metadataFileWriteBody, "$.TransferringBody") shouldEqual "Test"
-    JsonPath.read[String](metadataFileWriteBody, "$.MetadataSchemaLibraryVersion") shouldEqual "Schema-Library-Version-v0.1"
+    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
+    JsonPath.read[java.util.List[Any]](metadataFileWriteBody, "$.[0].FFID").asScala.toArray shouldEqual Array.empty[Any]
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].PropertyName") shouldEqual "Value"
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].Series") shouldEqual "Test"
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].TransferInitiatedDatetime") shouldEqual "2024-08-29 00:00:00"
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].ConsignmentReference") shouldEqual consignmentReference
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].TransferringBody") shouldEqual "Test"
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].MetadataSchemaLibraryVersion") shouldEqual "Schema-Library-Version-v0.1"
 
   }
 
@@ -128,10 +128,10 @@ class MainTest extends TestUtils {
     addFileMetadata(redactedMetadata, mappedPort, includeFFIDMetadata = false)
     Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
-    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT).drop(1).dropRight(1)
+    val metadataFileWriteBody = getRequestBody(req => req.getRequest.getUrl == s"/${fileIds.head}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
 
-    JsonPath.read[java.util.List[Any]](metadataFileWriteBody, "$.FFID").asScala.toArray shouldEqual Array.empty[Any]
-    JsonPath.read[String](metadataFileWriteBody, "$.OriginalFilepath") shouldEqual "/a/test/path"
+    JsonPath.read[java.util.List[Any]](metadataFileWriteBody, "$.[0].FFID").asScala.toArray shouldEqual Array.empty[Any]
+    JsonPath.read[String](metadataFileWriteBody, "$.[0].OriginalFilepath") shouldEqual "/a/test/path"
   }
 
   "run" should "return an error if there is no consignment entry" in withContainers {

--- a/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
@@ -22,7 +22,7 @@ class PublishUtilsTest extends AnyFlatSpec with MockitoSugar {
 
     when(snsUtils.publish(any[String], any[String]))
       .thenReturn(response(400), List.fill(10)(response(400)) ++ List(response(200)):_*)
-    val outputs = (1 to 600).map(_ => FileOutput("", UUID.randomUUID, None, None)).toList
+    val outputs = (1 to 600).map(_ => FileOutput("", UUID.randomUUID, UUID.randomUUID, None, None)).toList
 
     val fileOutputs = TestControl.executeEmbed(new PublishUtils(snsUtils, config).publishMessages(outputs))
 

--- a/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
@@ -49,8 +49,8 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     copyObjectRequests.count(_.sourceKey() == s"$consignmentId/$fileIdOne") should equal(1)
     copyObjectRequests.count(_.sourceKey() == s"$consignmentId/$fileIdTwo") should equal(1)
 
-    copyObjectRequests.count(_.destinationKey() == fileIdOne.toString) should equal(1)
-    copyObjectRequests.count(_.destinationKey() == fileIdTwo.toString) should equal(1)
+    copyObjectRequests.count(_.destinationKey().startsWith(fileIdOne.toString)) should equal(1)
+    copyObjectRequests.count(_.destinationKey().startsWith(fileIdTwo.toString)) should equal(1)
   }
 
   "copyFiles" should "return the correct number of files if the initial call to list objects is truncated" in {
@@ -194,7 +194,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
       .unsafeRunSync()
 
     val body = bodyCaptor.getValue.contentStreamProvider().newStream().readAllBytes().map(_.toChar).mkString
-    body should equal("""{"FFID":[],"TestFile":"TestFileValue","TestConsignment":"TestConsignmentValue"}""")
+    body should equal("""[{"FFID":[],"TestFile":"TestFileValue","TestConsignment":"TestConsignmentValue"}]""")
   }
 
   "createMetadata" should s"not write metadata if the file is not in the list of file ids" in {
@@ -217,7 +217,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
       .unsafeRunSync()
 
     val body = bodyCaptor.getValue.contentStreamProvider().newStream().readAllBytes().map(_.toChar).mkString
-    body should equal("""{"FFID":[],"TestFile1":"TestFileValue1"}""")
+    body should equal("""[{"FFID":[],"TestFile1":"TestFileValue1"}]""")
   }
 
   "createMetadata" should s"return an error if there is an error writing to s3" in {

--- a/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model._
 import Main._
 import MetadataUtils._
+import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
 
 import java.util.UUID
 import scala.jdk.CollectionConverters.ListHasAsScala
@@ -168,7 +169,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
 
       when(client.putObject(putObjectRequestCaptor.capture(), any[RequestBody])).thenReturn(PutObjectResponse.builder.build)
 
-      utils.putMetadata(consignmentType, List(fileId), Nil, List(Metadata(UUID.randomUUID(), "Test", "TestValue")), Map.empty).unsafeRunSync()
+      utils.putMetadata(consignmentType, List(FileOutput("", fileId, UUID.randomUUID, None, None)), Nil, List(Metadata(UUID.randomUUID(), "Test", "TestValue")), Map.empty).unsafeRunSync()
 
       putObjectRequestCaptor.getValue.bucket() should equal(bucket)
     }
@@ -186,7 +187,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     utils
       .putMetadata(
         Standard,
-        List(fileId),
+        List(FileOutput("", fileId, UUID.randomUUID, None, None)),
         List(Metadata(fileId, "TestFile", "TestFileValue")),
         List(Metadata(UUID.randomUUID(), "TestConsignment", "TestConsignmentValue")),
         Map.empty
@@ -194,7 +195,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
       .unsafeRunSync()
 
     val body = bodyCaptor.getValue.contentStreamProvider().newStream().readAllBytes().map(_.toChar).mkString
-    body should equal("""[{"FFID":[],"TestFile":"TestFileValue","TestConsignment":"TestConsignmentValue"}]""")
+    body.startsWith("""[{"FFID":[],"TestFile":"TestFileValue","TestConsignment":"TestConsignmentValue","fileId":"""") should equal(true)
   }
 
   "createMetadata" should s"not write metadata if the file is not in the list of file ids" in {
@@ -209,7 +210,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     utils
       .putMetadata(
         Standard,
-        List(fileId),
+        List(FileOutput("", fileId, UUID.randomUUID, None, None)),
         List(Metadata(fileId, "TestFile1", "TestFileValue1"), Metadata(UUID.randomUUID(), "TestFile2", "TestFileValue2")),
         Nil,
         Map.empty
@@ -217,7 +218,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
       .unsafeRunSync()
 
     val body = bodyCaptor.getValue.contentStreamProvider().newStream().readAllBytes().map(_.toChar).mkString
-    body should equal("""[{"FFID":[],"TestFile1":"TestFileValue1"}]""")
+    body.startsWith("""[{"FFID":[],"TestFile1":"TestFileValue1","fileId":"""") should equal(true)
   }
 
   "createMetadata" should s"return an error if there is an error writing to s3" in {
@@ -230,7 +231,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     val response = utils
       .putMetadata(
         Standard,
-        List(fileId),
+        List(FileOutput("", fileId, UUID.randomUUID, None, None)),
         List(Metadata(fileId, "TestFile1", "TestFileValue1")),
         Nil,
         Map.empty

--- a/export/src/test/scala/uk/gov/nationalarchives/export/TestUtils.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/TestUtils.scala
@@ -82,7 +82,7 @@ class TestUtils extends AnyFlatSpec with TestContainerForAll with BeforeAndAfter
           <ETag>"9b2cf535f27731c974343645a3985328"</ETag>
         </CopyObjectResult>
       s3Server.stubFor(
-        head(urlEqualTo(destinationName))
+        head(urlMatching(s"$destinationName/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"))
           .willReturn(ok().withHeader("Content-Length", "1"))
       )
       s3Server.stubFor(
@@ -90,7 +90,7 @@ class TestUtils extends AnyFlatSpec with TestContainerForAll with BeforeAndAfter
           .willReturn(ok().withHeader("Content-Length", "1"))
       )
       s3Server.stubFor(
-        put(urlEqualTo(destinationName))
+        put(urlMatching(s"$destinationName/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"))
           .withHost(equalTo("output.localhost"))
           .withHeader("x-amz-copy-source", equalTo(s"clean$sourceName"))
           .willReturn(okXml(response.toString()))


### PR DESCRIPTION
We're making some changes to the DR2 ingest process that will allow us
to start taking digitised records which have more than one file per
asset.

So I don't need complicated logic to work out which source things are
coming from, I want to change this export to match the new format. There
are three changes.

* The uploaded file is stored in the export bucket under $fileId/$randomUuid
* The metadata in the metadata file is now an array with one object
* The randomUuid is added to the metadata as fileId

We're the only ones using this so I won't break anything else.
