### PR TITLE
fix build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         run: |
           git config --global user.email 181243999+tna-da-bot@users.noreply.github.com
           git config --global user.name tna-da-bot
+          git remote set-url origin https://x-access-token:${{ secrets.WORKFLOW_PAT }}@github.com/${{ github.repository }}
           git checkout -b $BRANCH_NAME
           git push -u origin $BRANCH_NAME
           sbt 'release with-defaults'


### PR DESCRIPTION
The [error](https://github.com/nationalarchives/tdr-consignment-export/actions/runs/25547283088/job/74988508936) occurs because persist-credentials: false is set in the checkout step, so no git credentials are available for git push. The fix is to set the remote URL to use the GITHUB_TOKEN before pushing.