### PR TITLE
Tdrd 1180 use correct file id value

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,10 +103,3 @@ lazy val bagitExport = (project in file("bagit-export"))
     dependencyOverrides += "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
     (Test / javaOptions) += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
   ).enablePlugins(JavaAppPackaging, UniversalPlugin, BuildInfoPlugin)
-
-ThisBuild / dependencyOverrides ++= Seq(
-  "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
-  "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
-  "org.bouncycastle" % "bcutil-jdk18on" % "1.84",
-  "org.bouncycastle" % "bcpg-jdk18on"   % "1.84"
-)

--- a/build.sbt
+++ b/build.sbt
@@ -103,3 +103,10 @@ lazy val bagitExport = (project in file("bagit-export"))
     dependencyOverrides += "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
     (Test / javaOptions) += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
   ).enablePlugins(JavaAppPackaging, UniversalPlugin, BuildInfoPlugin)
+
+ThisBuild / dependencyOverrides ++= Seq(
+  "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
+  "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
+  "org.bouncycastle" % "bcutil-jdk18on" % "1.84",
+  "org.bouncycastle" % "bcpg-jdk18on"   % "1.84"
+)

--- a/build.sbt
+++ b/build.sbt
@@ -30,12 +30,6 @@ lazy val root = (project in file("."))
       setNextVersion,
       commitNextVersion,
       pushChanges
-    ),
-    dependencyOverrides ++= Seq(
-      "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
-      "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
-      "org.bouncycastle" % "bcutil-jdk18on" % "1.84",
-      "org.bouncycastle" % "bcpg-jdk18on"   % "1.84"
     )
   )
   .aggregate(bagitExport, export)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
-import Dependencies._
-import ReleaseTransformations._
+import Dependencies.*
+import ReleaseTransformations.*
+import sbt.Keys.dependencyOverrides
+
 import java.io.FileWriter
 
 ThisBuild / scalaVersion := "2.13.18"
@@ -28,6 +30,12 @@ lazy val root = (project in file("."))
       setNextVersion,
       commitNextVersion,
       pushChanges
+    ),
+    dependencyOverrides ++= Seq(
+      "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
+      "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
+      "org.bouncycastle" % "bcutil-jdk18on" % "1.84",
+      "org.bouncycastle" % "bcpg-jdk18on"   % "1.84"
     )
   )
   .aggregate(bagitExport, export)
@@ -73,7 +81,7 @@ lazy val export = (project in file("export"))
       jsonpath % Test
     ),
     name := "tdr-export",
-    (Universal / packageName) := "tdr-export",
+    (Universal / packageName) := "tdr-export"
   ).enablePlugins(JavaAppPackaging, UniversalPlugin, BuildInfoPlugin)
 
 lazy val bagitExport = (project in file("bagit-export"))
@@ -95,3 +103,10 @@ lazy val bagitExport = (project in file("bagit-export"))
     dependencyOverrides += "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2",
     (Test / javaOptions) += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
   ).enablePlugins(JavaAppPackaging, UniversalPlugin, BuildInfoPlugin)
+
+ThisBuild / dependencyOverrides ++= Seq(
+  "org.bouncycastle" % "bcprov-jdk18on" % "1.84",
+  "org.bouncycastle" % "bcpkix-jdk18on" % "1.84",
+  "org.bouncycastle" % "bcutil-jdk18on" % "1.84",
+  "org.bouncycastle" % "bcpg-jdk18on"   % "1.84"
+)

--- a/export/src/main/scala/uk/gov/nationalarchives/export/Main.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/Main.scala
@@ -47,10 +47,10 @@ object Main extends CommandIOApp("tdr-export", "Exports tdr files with a flat st
       _ <- IO.raiseWhen(fileMetadata.isEmpty)(new RuntimeException(s"Metadata for consignment $consignmentId is missing"))
       objectKeyIds = ObjectKeyIdHandler.getObjectKeyIds(fileMetadata)
       userId = UUID.fromString(consignmentMetadata.find(_.propertyName == UserId.id).get.value)
-      fileOutputs <- s3Utils.copyFiles(userId, consignmentId, consignmentType, consignmentMetadata, objectKeyIds)
+      fileDetails <- s3Utils.copyFiles(userId, consignmentId, consignmentType, consignmentMetadata, objectKeyIds)
       ffidMetadata <- metadataUtils.getFFIDMetadata(consignmentId)
-      _ <- s3Utils.putMetadata(userId, consignmentId, consignmentType, fileOutputs, fileMetadata, consignmentMetadata, ffidMetadata)
-      _ <- if (config.exportConfiguration.blockMockSeriesIngest && series.toLowerCase.contains("mock")) { IO(Nil) } else publishUtils.publishMessages(fileOutputs)
+      _ <- s3Utils.putMetadata(userId, consignmentId, consignmentType, fileDetails, fileMetadata, consignmentMetadata, ffidMetadata)
+      _ <- if (config.exportConfiguration.blockMockSeriesIngest && series.toLowerCase.contains("mock")) { IO(Nil) } else publishUtils.publishMessages(fileDetails.map(_.output))
       _ <- stepFunction.publishSuccess(taskToken)
       _ <- heartBeat.cancel
     } yield ExitCode.Success

--- a/export/src/main/scala/uk/gov/nationalarchives/export/ObjectKeyIdHandler.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/ObjectKeyIdHandler.scala
@@ -4,23 +4,23 @@ import java.util.UUID
 import uk.gov.nationalarchives.`export`.MetadataUtils.{Metadata, AssetId}
 
 object ObjectKeyIdHandler {
-  case class ObjectKeyIds(assetId: UUID, digitalObjectKeyId: UUID)
+  case class ObjectKeyIds(assetId: UUID, digitalObjectKeyId: UUID, tdrFileId: UUID)
 
   def getObjectKeyIds(fileMetadata: List[Metadata]): Map[UUID, ObjectKeyIds] = {
     val groupedMetadata = fileMetadata.groupBy(fm => fm.id)
     groupedMetadata.map(gm => {
-      val fileId = gm._1
+      val tdrFileId = gm._1
       val metadata = gm._2
       val noPersistedAssetId = !metadata.exists(_.propertyName == AssetId.id)
 
       //Keep current behaviour until all legacy consignments without asset ids persisted have been processed
       //Current behaviour use fileId as assetId and generate random UUID for the file object key id
-      if (noPersistedAssetId) {
-        fileId -> ObjectKeyIds(fileId, UUID.randomUUID())
-      } else {
+      val objectKeyIds = if (noPersistedAssetId) { ObjectKeyIds(tdrFileId, UUID.randomUUID(), tdrFileId) } else {
         val persistedAssetId = metadata.find(_.propertyName == AssetId.id).get.value
-        fileId -> ObjectKeyIds(UUID.fromString(persistedAssetId), fileId)
+        ObjectKeyIds(UUID.fromString(persistedAssetId), tdrFileId, tdrFileId)
       }
+
+      tdrFileId -> objectKeyIds
     })
   }
 }

--- a/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.s3.model.{CopyObjectRequest, ListObjectsV
 import uk.gov.nationalarchives.`export`.Main.Config
 import uk.gov.nationalarchives.`export`.MetadataUtils.{ConsignmentId, ConsignmentType, Judgment, Metadata, Series, Standard, TransferringBody, UserId}
 import uk.gov.nationalarchives.`export`.ObjectKeyIdHandler.ObjectKeyIds
-import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
+import uk.gov.nationalarchives.`export`.S3Utils.{FileDetails, FileOutput}
 
 import java.util.UUID
 import scala.annotation.tailrec
@@ -56,7 +56,7 @@ class S3Utils(config: Config, s3Client: S3Client) {
   }
 
   def copyFiles(userId: UUID, consignmentId: UUID, consignmentType: ConsignmentType, consignmentMetadata: List[Metadata],
-                objectKeyIds: Map[UUID, ObjectKeyIds]): IO[List[FileOutput]] = IO.blocking {
+                objectKeyIds: Map[UUID, ObjectKeyIds]): IO[List[FileDetails]] = IO.blocking {
     val destinationBucket = consignmentType match {
       case Judgment => config.s3.outputBucketJudgment
       case Standard => config.s3.outputBucket
@@ -65,8 +65,8 @@ class S3Utils(config: Config, s3Client: S3Client) {
     getAllObjects(s"$consignmentId/")
       .map { s3Object =>
         val key = s3Object.key
-        val fileId = UUID.fromString(key.split("/").last)
-        val ids = objectKeyIds(fileId)
+        val tdrFileId = UUID.fromString(key.split("/").last)
+        val ids = objectKeyIds(tdrFileId)
         val destinationKey = s"${ids.assetId}/${ids.digitalObjectKeyId}"
         val copyRequest = CopyObjectRequest
           .builder()
@@ -80,18 +80,19 @@ class S3Utils(config: Config, s3Client: S3Client) {
         s3Client.copyObject(copyRequest)
         val series = consignmentMetadata.find(_.propertyName == Series.id).map(_.value)
         val body = consignmentMetadata.find(_.propertyName == TransferringBody.id).map(_.value)
-        FileOutput(destinationBucket, ids.assetId, fileId, body, series)
+        val output = FileOutput(destinationBucket, ids.assetId, ids.digitalObjectKeyId, body, series)
+        FileDetails(output, ids)
       }
   }
 
   def putMetadata(
-     userId: UUID,
-     consignmentId: UUID,
-     consignmentType: ConsignmentType,
-     fileOutputs: List[FileOutput],
-     fileMetadata: List[Metadata],
-     consignmentMetadata: List[Metadata],
-     ffidMetadata: Map[UUID, List[MetadataUtils.FFID]]
+                   userId: UUID,
+                   consignmentId: UUID,
+                   consignmentType: ConsignmentType,
+                   fileDetails: List[FileDetails],
+                   fileMetadata: List[Metadata],
+                   consignmentMetadata: List[Metadata],
+                   ffidMetadata: Map[UUID, List[MetadataUtils.FFID]]
   ): IO[Unit] = IO.blocking {
     val groupedMetadata = fileMetadata.groupBy(_.id)
     val outputBucket = consignmentType match {
@@ -102,12 +103,13 @@ class S3Utils(config: Config, s3Client: S3Client) {
     def jsonFromMetadata(metadata: List[Metadata]): Map[String, Json] =
       metadata.map(m => m.propertyName -> Json.fromString(m.value)).toMap
 
-    fileOutputs.foreach { fileOutput =>
-      val ffidArray = ffidMetadata.getOrElse(fileOutput.fileId, Nil)
+    fileDetails.foreach { fileDetails =>
+      val ids = fileDetails.objectKeyIds
+      val ffidArray = ffidMetadata.getOrElse(ids.tdrFileId, Nil)
       val metadataJson = groupedMetadata
-        .get(fileOutput.fileId)
+        .get(ids.tdrFileId)
         .map(jsonFromMetadata)
-        .getOrElse(Map.empty) ++ jsonFromMetadata(consignmentMetadata) ++ Map("fileId" -> Json.fromString(fileOutput.fileId.toString))
+        .getOrElse(Map.empty) ++ jsonFromMetadata(consignmentMetadata) ++ Map("fileId" -> Json.fromString(ids.digitalObjectKeyId.toString))
       val ffidObject = JsonObject.fromMap(Map("FFID" -> ffidArray.asJson))
       val allObjects = JsonObject
         .fromMap(metadataJson)
@@ -117,7 +119,7 @@ class S3Utils(config: Config, s3Client: S3Client) {
       val body = RequestBody.fromString(Json.arr(allObjects).noSpaces)
       val request = PutObjectRequest.builder
         .bucket(outputBucket)
-        .key(s"${fileOutput.assetId}.metadata")
+        .key(s"${ids.assetId}.metadata")
         .tagging(contextTagging(userId, consignmentId))
         .build
       s3Client.putObject(request, body)
@@ -127,6 +129,6 @@ class S3Utils(config: Config, s3Client: S3Client) {
 
 object S3Utils {
   def apply(config: Config, s3Client: S3Client) = new S3Utils(config, s3Client)
-
+  case class FileDetails(output: FileOutput, objectKeyIds: ObjectKeyIds)
   case class FileOutput(bucket: String, assetId: UUID, fileId: UUID, transferringBody: Option[String], series: Option[String])
 }

--- a/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
@@ -15,16 +15,17 @@ import scala.jdk.CollectionConverters.ListHasAsScala
 
 class MainTest extends TestUtils {
 
-  "run" should "use file id as asset id where no asset id persisted" in withContainers {
+  "run" should "use the tdr file id as asset id where no asset id persisted" in withContainers {
     container: PostgreSQLContainer =>
       val mappedPort = container.mappedPort(5432)
       val seriesName: String = UUID.randomUUID().toString
       val (consignmentId, testRecordIds, consignmentReference) = stubExternalServices(mappedPort, seriesName = seriesName, persistedAssetIds = false)
       Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
 
+      val metadataKeyId = testRecordIds.head.fileId
       val serveEvents = s3Server.getAllServeEvents.asScala
       val metadataFileWriteBody = serveEvents
-        .find(req => req.getRequest.getUrl == s"/${testRecordIds.head.fileId}.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
+        .find(req => req.getRequest.getUrl == s"/$metadataKeyId.metadata" && req.getRequest.getMethod == RequestMethod.PUT)
         .map(_.getRequest.getBodyAsString)
         .getOrElse("")
       val jsonReturned = metadataFileWriteBody.split("\n").tail.head.trim
@@ -33,7 +34,7 @@ class MainTest extends TestUtils {
       JsonPath.read[java.util.List[Any]](jsonReturned, "$.[0].FFID").asScala.toArray shouldEqual Array.empty[Any]
       JsonPath.read[String](jsonReturned, "$.[0].PropertyName") shouldEqual "Value"
       JsonPath.read[String](jsonReturned, "$.[0].UserId") shouldEqual userId
-      JsonPath.read[String](jsonReturned, "$.[0].fileId") shouldEqual testRecordIds.head.fileId.toString
+      JsonPath.read[String](jsonReturned, "$.[0].fileId") should not equal testRecordIds.head.fileId.toString
       JsonPath.read[String](jsonReturned, "$.[0].Series") shouldEqual seriesName
       JsonPath.read[String](jsonReturned, "$.[0].TransferInitiatedDatetime") shouldEqual "2024-08-29 00:00:00"
       JsonPath.read[String](jsonReturned, "$.[0].ConsignmentReference") shouldEqual consignmentReference
@@ -63,6 +64,21 @@ class MainTest extends TestUtils {
     val fileOutput = decode[FileOutput](snsMessage).value
     fileOutput.bucket should equal("output")
     fileOutput.assetId should equal(testRecordIds.head.assetId)
+    fileOutput.fileId should equal(testRecordIds.head.fileId)
+  }
+
+  "run" should "send a message to the SNS topic with the id of the file being a random id when no asset id persisted" in withContainers {
+    container: PostgreSQLContainer =>
+      val mappedPort = container.mappedPort(5432)
+      val (consignmentId, testRecordIds, _) = stubExternalServices(mappedPort, persistedAssetIds = false)
+      Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
+
+      val snsMessage = snsServer.getAllServeEvents.asScala.head.getRequest.getFormParameters.get("Message").values().get(0)
+      val fileOutput = decode[FileOutput](snsMessage).value
+      fileOutput.bucket should equal("output")
+      fileOutput.assetId should equal(testRecordIds.head.fileId)
+      fileOutput.fileId should not equal testRecordIds.head.fileId
+      fileOutput.fileId should not equal testRecordIds.head.assetId
   }
 
   "run" should "not send a message to the SNS topic for a 'mock' series" in withContainers {

--- a/export/src/test/scala/uk/gov/nationalarchives/export/ObjectKeyIdHandlerSpec.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/ObjectKeyIdHandlerSpec.scala
@@ -31,10 +31,12 @@ class ObjectKeyIdHandlerSpec extends AnyFlatSpec with MockitoSugar {
     val fileOneIds = result(fileOneId)
     fileOneIds.assetId shouldEqual fileOneAssetId
     fileOneIds.digitalObjectKeyId shouldEqual fileOneId
+    fileOneIds.tdrFileId shouldEqual fileOneId
 
     val fileTwoIds = result(fileTwoId)
     fileTwoIds.assetId shouldEqual fileTwoAssetId
     fileTwoIds.digitalObjectKeyId shouldEqual fileTwoId
+    fileTwoIds.tdrFileId shouldEqual fileTwoId
   }
 
   "getObjectKeyIds" should "return the file id as the asset id and generate a new digital object key id where asset id is not persisted" in {
@@ -53,9 +55,12 @@ class ObjectKeyIdHandlerSpec extends AnyFlatSpec with MockitoSugar {
     val fileWithoutAssetId = result(fileOneId)
     fileWithoutAssetId.assetId shouldEqual fileOneId
     fileWithoutAssetId.digitalObjectKeyId should not equal fileOneId
+    fileWithoutAssetId.digitalObjectKeyId should not equal fileOneAssetId
+    fileWithoutAssetId.tdrFileId shouldEqual fileOneId
 
     val fileTwoIds = result(fileTwoId)
     fileTwoIds.assetId shouldEqual fileTwoAssetId
     fileTwoIds.digitalObjectKeyId shouldEqual fileTwoId
+    fileTwoIds.tdrFileId shouldEqual fileTwoId
   }
 }

--- a/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
@@ -22,7 +22,7 @@ class PublishUtilsTest extends AnyFlatSpec with MockitoSugar {
 
     when(snsUtils.publish(any[String], any[String]))
       .thenReturn(response(400), List.fill(10)(response(400)) ++ List(response(200)):_*)
-    val outputs = (1 to 600).map(_ => FileOutput("", UUID.randomUUID, UUID.randomUUID, None, None)).toList
+    val outputs = (1 to 600).map(_ => FileOutput("", UUID.randomUUID(), UUID.randomUUID(), None, None)).toList
 
     val fileOutputs = TestControl.executeEmbed(new PublishUtils(snsUtils, config).publishMessages(outputs))
 

--- a/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.s3.model._
 import Main._
 import MetadataUtils._
 import uk.gov.nationalarchives.`export`.ObjectKeyIdHandler.ObjectKeyIds
-import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
+import uk.gov.nationalarchives.`export`.S3Utils.{FileDetails, FileOutput}
 
 import java.util.UUID
 import scala.jdk.CollectionConverters.ListHasAsScala
@@ -33,7 +33,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     val assetIdOne = UUID.randomUUID()
     val fileIdOne = UUID.randomUUID()
     val objectKeyIds = Map(
-      fileIdOne -> ObjectKeyIds(assetIdOne, fileIdOne)
+      fileIdOne -> ObjectKeyIds(assetIdOne, fileIdOne, UUID.randomUUID())
     )
     val listObjectsCaptor: ArgumentCaptor[ListObjectsV2Request] = ArgumentCaptor.forClass(classOf[ListObjectsV2Request])
     val copyObjectCaptor: ArgumentCaptor[CopyObjectRequest] = ArgumentCaptor.forClass(classOf[CopyObjectRequest])
@@ -66,8 +66,8 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     val fileIdOne = UUID.randomUUID()
     val fileIdTwo = UUID.randomUUID()
     val objectKeyIds = Map(
-      fileIdOne -> ObjectKeyIds(assetIdOne, fileIdOne),
-      fileIdTwo -> ObjectKeyIds(assetIdTwo, fileIdTwo)
+      fileIdOne -> ObjectKeyIds(assetIdOne, fileIdOne, UUID.randomUUID()),
+      fileIdTwo -> ObjectKeyIds(assetIdTwo, fileIdTwo, UUID.randomUUID())
     )
     val listObjectsCaptor: ArgumentCaptor[ListObjectsV2Request] = ArgumentCaptor.forClass(classOf[ListObjectsV2Request])
     val copyObjectCaptor: ArgumentCaptor[CopyObjectRequest] = ArgumentCaptor.forClass(classOf[CopyObjectRequest])
@@ -107,8 +107,8 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     val fileIdOne = UUID.randomUUID()
     val fileIdTwo = UUID.randomUUID()
     val objectKeyIds = Map(
-      fileIdOne -> ObjectKeyIds(assetIdOne, fileIdOne),
-      fileIdTwo -> ObjectKeyIds(assetIdTwo, fileIdTwo)
+      fileIdOne -> ObjectKeyIds(assetIdOne, fileIdOne, UUID.randomUUID()),
+      fileIdTwo -> ObjectKeyIds(assetIdTwo, fileIdTwo, UUID.randomUUID())
     )
     val listObjectsCaptor: ArgumentCaptor[ListObjectsV2Request] = ArgumentCaptor.forClass(classOf[ListObjectsV2Request])
 
@@ -160,7 +160,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     val consignmentId = UUID.randomUUID()
     val assetIdOne = UUID.randomUUID()
     val fileIdOne = UUID.randomUUID()
-    val objectKeyIds = Map(fileIdOne -> ObjectKeyIds(assetIdOne, fileIdOne))
+    val objectKeyIds = Map(fileIdOne -> ObjectKeyIds(assetIdOne, fileIdOne, UUID.randomUUID()))
     val s3Object = S3Object.builder.key(s"$consignmentId/$fileIdOne").build
     val listObjectsV2Response = ListObjectsV2Response.builder.contents(s3Object).build
 
@@ -203,7 +203,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
       val consignmentId = UUID.randomUUID()
       val assetId = UUID.randomUUID()
       val fileId = UUID.randomUUID()
-      val objectKeyIds = Map(fileId -> ObjectKeyIds(assetId, fileId))
+      val objectKeyIds = Map(fileId -> ObjectKeyIds(assetId, fileId, UUID.randomUUID()))
       val copyObjectCaptor: ArgumentCaptor[CopyObjectRequest] = ArgumentCaptor.forClass(classOf[CopyObjectRequest])
 
       val s3Object = S3Object.builder.key(s"$consignmentId/$fileId").build
@@ -231,7 +231,10 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
 
       when(client.putObject(putObjectRequestCaptor.capture(), any[RequestBody])).thenReturn(PutObjectResponse.builder.build)
 
-      utils.putMetadata(userId, consignmentId, consignmentType, List(FileOutput("", assetId, UUID.randomUUID, None, None)), Nil, List(Metadata(UUID.randomUUID(), "Test", "TestValue")), Map.empty).unsafeRunSync()
+      val objectKeyIds = ObjectKeyIds(assetId, UUID.randomUUID(), UUID.randomUUID())
+      val fileOutput = FileOutput("", assetId, UUID.randomUUID, None, None)
+
+      utils.putMetadata(userId, consignmentId, consignmentType, List(FileDetails(fileOutput, objectKeyIds)), Nil, List(Metadata(UUID.randomUUID(), "Test", "TestValue")), Map.empty).unsafeRunSync()
 
       putObjectRequestCaptor.getValue.bucket() should equal(bucket)
       putObjectRequestCaptor.getValue.tagging() should equal(s"ConsignmentId=$consignmentId&UserId=$userId")
@@ -249,12 +252,15 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
 
     when(client.putObject(any[PutObjectRequest], bodyCaptor.capture())).thenReturn(PutObjectResponse.builder.build)
 
+    val objectKeyIds = ObjectKeyIds(assetId, UUID.randomUUID(), fileId)
+    val fileOutput = FileOutput("", assetId, UUID.randomUUID, None, None)
+
     utils
       .putMetadata(
         UUID.randomUUID(),
         UUID.randomUUID(),
         Standard,
-        List(FileOutput("", assetId, fileId, None, None)),
+        List(FileDetails(fileOutput, objectKeyIds)),
         List(Metadata(fileId, "TestFile", "TestFileValue")),
         List(Metadata(UUID.randomUUID(), "TestConsignment", "TestConsignmentValue")),
         Map.empty
@@ -275,12 +281,15 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
 
     when(client.putObject(any[PutObjectRequest], bodyCaptor.capture())).thenReturn(PutObjectResponse.builder.build)
 
+    val objectKeyIds = ObjectKeyIds(assetId, UUID.randomUUID(), fileId)
+    val fileOutput = FileOutput("", assetId, UUID.randomUUID, None, None)
+
     utils
       .putMetadata(
         UUID.randomUUID(),
         UUID.randomUUID(),
         Standard,
-        List(FileOutput("", assetId, fileId, None, None)),
+        List(FileDetails(fileOutput, objectKeyIds)),
         List(Metadata(fileId, "TestFile1", "TestFileValue1"), Metadata(UUID.randomUUID(), "TestFile2", "TestFileValue2")),
         Nil,
         Map.empty
@@ -298,12 +307,15 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
 
     when(client.putObject(any[PutObjectRequest], any[RequestBody])).thenThrow(new Exception("Error writing to S3"))
 
+    val objectKeyIds = ObjectKeyIds(assetId, UUID.randomUUID(), UUID.randomUUID())
+    val fileOutput = FileOutput("", assetId, UUID.randomUUID, None, None)
+
     val response = utils
       .putMetadata(
         UUID.randomUUID(),
         UUID.randomUUID(),
         Standard,
-        List(FileOutput("", assetId, UUID.randomUUID, None, None)),
+        List(FileDetails(fileOutput, objectKeyIds)),
         List(Metadata(assetId, "TestFile1", "TestFileValue1")),
         Nil,
         Map.empty

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   private val githubPureConfigVersion = "0.17.10"
-  private val keycloakVersion = "26.6.4"
+  private val keycloakVersion = "26.7.0"
   private val log4CatsVersion = "2.8.0"
   private val mockitoScalaVersion = "2.2.1"
   private val monovoreDeclineVersion = "2.6.2"
@@ -10,9 +10,9 @@ object Dependencies {
   private val doobieVersion = "1.0.0-RC13"
   private val testContainersVersion = "0.44.1"
 
-  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.292"
-  lazy val awsRds = "software.amazon.awssdk" % "rds" % "2.46.21"
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.478"
+  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.293"
+  lazy val awsRds = "software.amazon.awssdk" % "rds" % "2.47.3"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.479"
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % awsUtilsVersion
   lazy val stepFunctionUtils = "uk.gov.nationalarchives" %% "stepfunction-utils" % "0.1.338"
   lazy val snsUtils = "uk.gov.nationalarchives" %% "sns-utils" % awsUtilsVersion
@@ -23,8 +23,8 @@ object Dependencies {
   lazy val declineEffect = "com.monovore" %% "decline-effect" % monovoreDeclineVersion
   lazy val doobie = "org.typelevel" %% "doobie-core" % doobieVersion
   lazy val doobiePostgres = "org.typelevel" %% "doobie-postgres"  % doobieVersion
-  lazy val postgres = "org.postgresql" % "postgresql" % "42.7.12"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.304"
+  lazy val postgres = "org.postgresql" % "postgresql" % "42.7.13"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.305"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.20"
   lazy val scalaCsv = "com.github.tototoshi" %% "scala-csv" % "2.0.0"
   lazy val log4cats = "org.typelevel" %% "log4cats-core" % log4CatsVersion
@@ -40,5 +40,5 @@ object Dependencies {
   lazy val testContainersPostgres = "com.dimafeng" %% "testcontainers-scala-postgresql" % testContainersVersion
   lazy val wiremock = "org.wiremock" % "wiremock" % "3.13.2"
   lazy val jsonpath = "com.jayway.jsonpath" % "json-path-assert" % "3.0.0"
-  lazy val schemaConfig = "uk.gov.nationalarchives" %% "da-metadata-schema"% "0.0.136"
+  lazy val schemaConfig = "uk.gov.nationalarchives" %% "da-metadata-schema"% "0.0.137"
 }


### PR DESCRIPTION
The 'FileOutput' case class cannot be changed to avoid breaking DR2 as it is used as the SNS message.

Use a wrapper case class to provide all necessary information for other functions, including the FileOutput after S3 copying