### PR TITLE
Metadata location as s3 url

### DIFF
--- a/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
+++ b/export/src/main/scala/uk/gov/nationalarchives/export/S3Utils.scala
@@ -12,6 +12,7 @@ import uk.gov.nationalarchives.`export`.MetadataUtils.{ConsignmentId, Consignmen
 import uk.gov.nationalarchives.`export`.ObjectKeyIdHandler.ObjectKeyIds
 import uk.gov.nationalarchives.`export`.S3Utils.{FileDetails, FileOutput}
 
+import java.net.URI
 import java.util.UUID
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters._
@@ -80,7 +81,7 @@ class S3Utils(config: Config, s3Client: S3Client) {
         s3Client.copyObject(copyRequest)
         val series = consignmentMetadata.find(_.propertyName == Series.id).map(_.value)
         val body = consignmentMetadata.find(_.propertyName == TransferringBody.id).map(_.value)
-        val metadataLocation = s"${ids.assetId}.metadata"
+        val metadataLocation = URI.create(s"s3://$destinationBucket/${ids.assetId}.metadata")
         val output = FileOutput(destinationBucket, ids.assetId, ids.digitalObjectKeyId, metadataLocation, body, series)
         FileDetails(output, ids)
       }
@@ -120,7 +121,7 @@ class S3Utils(config: Config, s3Client: S3Client) {
       val body = RequestBody.fromString(Json.arr(allObjects).noSpaces)
       val request = PutObjectRequest.builder
         .bucket(outputBucket)
-        .key(fileDetails.output.metadataLocation)
+        .key(fileDetails.output.metadataLocation.getPath.drop(1))
         .tagging(contextTagging(userId, consignmentId))
         .build
       s3Client.putObject(request, body)
@@ -131,6 +132,6 @@ class S3Utils(config: Config, s3Client: S3Client) {
 object S3Utils {
   def apply(config: Config, s3Client: S3Client) = new S3Utils(config, s3Client)
   case class FileDetails(output: FileOutput, objectKeyIds: ObjectKeyIds)
-  case class FileOutput(bucket: String, assetId: UUID, fileId: UUID, metadataLocation: String,
+  case class FileOutput(bucket: String, assetId: UUID, fileId: UUID, metadataLocation: URI,
                         transferringBody: Option[String], series: Option[String])
 }

--- a/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/MainTest.scala
@@ -10,6 +10,7 @@ import org.scalatest.matchers.should.Matchers._
 import uk.gov.nationalarchives.`export`.MetadataUtils.Metadata
 import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
 
+import java.net.URI
 import java.util.UUID
 import scala.jdk.CollectionConverters.ListHasAsScala
 
@@ -65,6 +66,17 @@ class MainTest extends TestUtils {
     fileOutput.bucket should equal("output")
     fileOutput.assetId should equal(testRecordIds.head.assetId)
     fileOutput.fileId should equal(testRecordIds.head.fileId)
+  }
+
+  "run" should "send a message to the SNS topic with the metadata location" in withContainers {
+    container: PostgreSQLContainer =>
+      val mappedPort = container.mappedPort(5432)
+      val (consignmentId, testRecordIds, _) = stubExternalServices(mappedPort)
+      Main.run(List("export", "--consignmentId", consignmentId.toString, "--taskToken", "taskToken")).unsafeRunSync()
+
+      val snsMessage = snsServer.getAllServeEvents.asScala.head.getRequest.getFormParameters.get("Message").values().get(0)
+      val fileOutput = decode[FileOutput](snsMessage).value
+      fileOutput.metadataLocation should equal(URI.create(s"s3://output/${testRecordIds.head.assetId}.metadata"))
   }
 
   "run" should "send a message to the SNS topic with the id of the file being a random id when no asset id persisted" in withContainers {

--- a/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/PublishUtilsTest.scala
@@ -11,6 +11,7 @@ import uk.gov.nationalarchives.`export`.Main.{Config, Db, ExportConfiguration, S
 import uk.gov.nationalarchives.`export`.S3Utils.FileOutput
 import uk.gov.nationalarchives.aws.utils.sns.SNSUtils
 
+import java.net.URI
 import java.util.UUID
 
 class PublishUtilsTest extends AnyFlatSpec with MockitoSugar {
@@ -22,7 +23,7 @@ class PublishUtilsTest extends AnyFlatSpec with MockitoSugar {
 
     when(snsUtils.publish(any[String], any[String]))
       .thenReturn(response(400), List.fill(10)(response(400)) ++ List(response(200)):_*)
-    val outputs = (1 to 600).map(_ => FileOutput("", UUID.randomUUID(), UUID.randomUUID(), "metadataLocation", None, None)).toList
+    val outputs = (1 to 600).map(_ => FileOutput("", UUID.randomUUID(), UUID.randomUUID(), URI.create("s3://bucket/metadataLocation"), None, None)).toList
 
     val fileOutputs = TestControl.executeEmbed(new PublishUtils(snsUtils, config).publishMessages(outputs))
 

--- a/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
+++ b/export/src/test/scala/uk/gov/nationalarchives/export/S3UtilsTest.scala
@@ -15,6 +15,7 @@ import MetadataUtils._
 import uk.gov.nationalarchives.`export`.ObjectKeyIdHandler.ObjectKeyIds
 import uk.gov.nationalarchives.`export`.S3Utils.{FileDetails, FileOutput}
 
+import java.net.URI
 import java.util.UUID
 import scala.jdk.CollectionConverters.ListHasAsScala
 
@@ -232,7 +233,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
       when(client.putObject(putObjectRequestCaptor.capture(), any[RequestBody])).thenReturn(PutObjectResponse.builder.build)
 
       val objectKeyIds = ObjectKeyIds(assetId, UUID.randomUUID(), UUID.randomUUID())
-      val fileOutput = FileOutput("", assetId, UUID.randomUUID, "metadataLocation", None, None)
+      val fileOutput = FileOutput("", assetId, UUID.randomUUID, URI.create("s3://bucket/metadataLocation"), None, None)
 
       utils.putMetadata(userId, consignmentId, consignmentType, List(FileDetails(fileOutput, objectKeyIds)), Nil, List(Metadata(UUID.randomUUID(), "Test", "TestValue")), Map.empty).unsafeRunSync()
 
@@ -253,7 +254,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     when(client.putObject(any[PutObjectRequest], bodyCaptor.capture())).thenReturn(PutObjectResponse.builder.build)
 
     val objectKeyIds = ObjectKeyIds(assetId, UUID.randomUUID(), fileId)
-    val fileOutput = FileOutput("", assetId, UUID.randomUUID, "metadataLocation", None, None)
+    val fileOutput = FileOutput("", assetId, UUID.randomUUID, URI.create("s3://bucket/metadataLocation"), None, None)
 
     utils
       .putMetadata(
@@ -282,7 +283,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     when(client.putObject(any[PutObjectRequest], bodyCaptor.capture())).thenReturn(PutObjectResponse.builder.build)
 
     val objectKeyIds = ObjectKeyIds(assetId, UUID.randomUUID(), fileId)
-    val fileOutput = FileOutput("", assetId, UUID.randomUUID, "metadataLocation", None, None)
+    val fileOutput = FileOutput("", assetId, UUID.randomUUID, URI.create("s3://bucket/metadataLocation"), None, None)
 
     utils
       .putMetadata(
@@ -308,7 +309,7 @@ class S3UtilsTest extends AnyFlatSpec with MockitoSugar with EitherValues with T
     when(client.putObject(any[PutObjectRequest], any[RequestBody])).thenThrow(new Exception("Error writing to S3"))
 
     val objectKeyIds = ObjectKeyIds(assetId, UUID.randomUUID(), UUID.randomUUID())
-    val fileOutput = FileOutput("", assetId, UUID.randomUUID, "metadataLocation", None, None)
+    val fileOutput = FileOutput("", assetId, UUID.randomUUID, URI.create("s3://bucket/metadataLocation"), None, None)
 
     val response = utils
       .putMetadata(


### PR DESCRIPTION
For one of our other ingest routes, we're going to have the metadata and files in different buckets
so we need a full s3 uri as a metadata location.

This change keeps the TDR route the same.
